### PR TITLE
Fix: Constrain table output to terminal width

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.5
 require (
 	github.com/BRO3886/go-eventkit v0.2.1
 	github.com/charmbracelet/huh v0.8.0
+	github.com/charmbracelet/x/term v0.2.1
 	github.com/fatih/color v1.18.0
 	github.com/olekukonko/tablewriter v1.1.3
 	github.com/spf13/cobra v1.10.2
@@ -21,7 +22,6 @@ require (
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
-	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/clipperhouse/displaywidth v0.6.2 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.3.0 // indirect

--- a/internal/ui/output.go
+++ b/internal/ui/output.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/BRO3886/rem/internal/export"
 	"github.com/BRO3886/rem/internal/reminder"
+	"github.com/charmbracelet/x/term"
 	"github.com/fatih/color"
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/tw"
@@ -87,8 +88,16 @@ func PrintLists(w io.Writer, lists []*reminder.List, format OutputFormat, showCo
 	}
 }
 
+func terminalWidth() int {
+	w, _, err := term.GetSize(os.Stdout.Fd())
+	if err != nil || w <= 0 {
+		return 0
+	}
+	return w
+}
+
 func newTable(w io.Writer) *tablewriter.Table {
-	return tablewriter.NewTable(w,
+	opts := []tablewriter.Option{
 		tablewriter.WithHeaderAlignment(tw.AlignLeft),
 		tablewriter.WithRowAlignment(tw.AlignLeft),
 		tablewriter.WithRendition(tw.Rendition{
@@ -98,7 +107,11 @@ func newTable(w io.Writer) *tablewriter.Table {
 				},
 			},
 		}),
-	)
+	}
+	if width := terminalWidth(); width > 0 {
+		opts = append(opts, tablewriter.WithMaxWidth(width))
+	}
+	return tablewriter.NewTable(w, opts...)
 }
 
 func printRemindersTable(w io.Writer, reminders []*reminder.Reminder) {


### PR DESCRIPTION
Use charmbracelet/x/term to detect terminal width and pass it to tablewriter via WithMaxWidth, preventing table overflow on narrow terminals. Falls back when output is piped or not a TTY.