### PR TITLE
feat(list): sort reminders by due date then priority

### DIFF
--- a/internal/service/reminders.go
+++ b/internal/service/reminders.go
@@ -5,6 +5,7 @@ package service
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -120,6 +121,32 @@ func (s *ReminderService) ListReminders(filter *reminder.ListFilter) ([]*reminde
 
 		result = append(result, r)
 	}
+
+	sort.Slice(result, func(i, j int) bool {
+		ri, rj := result[i], result[j]
+
+		switch {
+		case ri.DueDate == nil && rj.DueDate == nil:
+			// fall through to priority
+		case ri.DueDate == nil:
+			return false
+		case rj.DueDate == nil:
+			return true
+		default:
+			if !ri.DueDate.Equal(*rj.DueDate) {
+				return ri.DueDate.Before(*rj.DueDate)
+			}
+		}
+
+		// Priority 0 (none) sorts last; otherwise lower value = higher priority
+		if ri.Priority == reminder.PriorityNone {
+			return false
+		}
+		if rj.Priority == reminder.PriorityNone {
+			return true
+		}
+		return ri.Priority < rj.Priority
+	})
 
 	return result, nil
 }


### PR DESCRIPTION
Reminders are sorted by due date ascending, with priority as tiebreaker. Reminders without a due date appear last. The sorting affects all output formats.