### PR TITLE
Add alarms, recurrence display, batch delete, and --remind-me flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ make build
 # List all reminder lists
 rem lists --count
 
-# Create a reminder
-rem add "Buy groceries" --list Personal --due tomorrow --priority high
+# Create a reminder with an alarm
+rem add "Buy groceries" --list Personal --due tomorrow --priority high --remind-me 15m
 
 # List incomplete reminders
 rem list --list Work --incomplete

--- a/cmd/rem/commands/add.go
+++ b/cmd/rem/commands/add.go
@@ -11,12 +11,13 @@ import (
 )
 
 var (
-	addList     string
-	addDue      string
-	addPriority string
-	addNotes    string
-	addURL      string
-	addFlagged  bool
+	addList       string
+	addDue        string
+	addPriority   string
+	addNotes      string
+	addURL        string
+	addFlagged    bool
+	addRemindMe   string
 	addInteractive bool
 )
 
@@ -28,6 +29,7 @@ var addCmd = &cobra.Command{
 	Example: `  rem add "Buy groceries" --list Personal --due tomorrow --priority high
   rem add "Review PR" --due "next friday at 2pm" --url https://github.com/org/repo/pull/123
   rem add "Call dentist" --due "in 2 days" --notes "Ask about cleaning"
+  rem add "Meeting" --due "tomorrow at 10am" --remind-me 15m
   rem add -i  # Interactive mode`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if addInteractive {
@@ -55,6 +57,14 @@ var addCmd = &cobra.Command{
 			r.DueDate = &dueDate
 		}
 
+		if addRemindMe != "" {
+			alarm, err := parseAlarm(addRemindMe)
+			if err != nil {
+				return err
+			}
+			r.Alarms = []reminder.Alarm{alarm}
+		}
+
 		id, err := reminderSvc.CreateReminder(r)
 		if err != nil {
 			return err
@@ -78,6 +88,7 @@ func init() {
 	addCmd.Flags().StringVarP(&addNotes, "notes", "n", "", "Notes/body for the reminder")
 	addCmd.Flags().StringVarP(&addURL, "url", "u", "", "URL to attach to the reminder")
 	addCmd.Flags().BoolVarP(&addFlagged, "flagged", "f", false, "Flag the reminder")
+	addCmd.Flags().StringVar(&addRemindMe, "remind-me", "", "Set alarm: duration before due (15m, 1h, 2d) or absolute time")
 	addCmd.Flags().BoolVarP(&addInteractive, "interactive", "i", false, "Create reminder interactively")
 
 	rootCmd.AddCommand(addCmd)

--- a/cmd/rem/commands/delete.go
+++ b/cmd/rem/commands/delete.go
@@ -14,10 +14,11 @@ var (
 )
 
 var deleteCmd = &cobra.Command{
-	Use:     "delete [id]",
+	Use:     "delete [id...]",
 	Aliases: []string{"rm", "remove"},
-	Short:   "Delete a reminder",
+	Short:   "Delete one or more reminders",
 	Example: `  rem delete abc12345
+  rem delete abc12345 def67890 --force
   rem rm abc12345 --force
   rem delete -i
   rem delete -i --list Work --flagged`,

--- a/cmd/rem/commands/delete.go
+++ b/cmd/rem/commands/delete.go
@@ -25,21 +25,34 @@ var deleteCmd = &cobra.Command{
 		if deleteInteractive {
 			return cobra.MaximumNArgs(0)(cmd, args)
 		}
-		return cobra.ExactArgs(1)(cmd, args)
+		return cobra.MinimumNArgs(1)(cmd, args)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if deleteInteractive {
 			return runDeleteInteractive()
 		}
 
-		r, err := findReminderByID(args[0])
-		if err != nil {
-			return err
+		// Resolve all IDs first
+		type resolved struct {
+			id   string
+			name string
+		}
+		var toDelete []resolved
+		for _, arg := range args {
+			r, err := findReminderByID(arg)
+			if err != nil {
+				return err
+			}
+			toDelete = append(toDelete, resolved{id: r.ID, name: r.Name})
 		}
 
 		if !deleteForce {
 			if isTTY() {
-				confirmed, err := huhConfirm(fmt.Sprintf("Delete reminder '%s'?", r.Name))
+				msg := fmt.Sprintf("Delete reminder '%s'?", toDelete[0].name)
+				if len(toDelete) > 1 {
+					msg = fmt.Sprintf("Delete %d reminders?", len(toDelete))
+				}
+				confirmed, err := huhConfirm(msg)
 				if err != nil {
 					return err
 				}
@@ -51,11 +64,23 @@ var deleteCmd = &cobra.Command{
 			}
 		}
 
-		if err := reminderSvc.DeleteReminder(r.ID); err != nil {
-			return err
+		if len(toDelete) == 1 {
+			if err := reminderSvc.DeleteReminder(toDelete[0].id); err != nil {
+				return err
+			}
+			fmt.Printf("Deleted: %s\n", toDelete[0].name)
+		} else {
+			ids := make([]string, len(toDelete))
+			for i, r := range toDelete {
+				ids[i] = r.id
+			}
+			errs := reminderSvc.DeleteReminders(ids)
+			for id, err := range errs {
+				fmt.Printf("Error deleting %s: %v\n", shortIDStr(id), err)
+			}
+			fmt.Printf("Deleted %d reminder(s)\n", len(toDelete)-len(errs))
 		}
 
-		fmt.Printf("Deleted: %s\n", r.Name)
 		return nil
 	},
 }
@@ -95,13 +120,11 @@ func runDeleteInteractive() error {
 		return nil
 	}
 
-	for _, id := range selected {
-		if err := reminderSvc.DeleteReminder(id); err != nil {
-			fmt.Printf("Error deleting %s: %v\n", shortIDStr(id), err)
-			continue
-		}
+	errs := reminderSvc.DeleteReminders(selected)
+	for id, err := range errs {
+		fmt.Printf("Error deleting %s: %v\n", shortIDStr(id), err)
 	}
 
-	fmt.Printf("Deleted %d reminder(s)\n", len(selected))
+	fmt.Printf("Deleted %d reminder(s)\n", len(selected)-len(errs))
 	return nil
 }

--- a/cmd/rem/commands/filters.go
+++ b/cmd/rem/commands/filters.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/BRO3886/go-eventkit/dateparser"
@@ -15,6 +16,23 @@ func parseDate(input string) (time.Time, error) {
 		dateparser.WithSmartTimeRollover(),
 		dateparser.WithEOWSkipToday(),
 	)
+}
+
+// parseAlarm parses an alarm specification. Supports:
+//   - Relative offsets: "15m", "1h", "2d", "0" (at time of event)
+//   - Absolute times: any input parseable by parseDate (e.g., "tomorrow at 9am")
+func parseAlarm(input string) (reminder.Alarm, error) {
+	// Try relative offset first (e.g., "15m", "1h", "2d")
+	if d, err := dateparser.ParseAlertDuration(input); err == nil {
+		return reminder.Alarm{RelativeOffset: -d}, nil // negative = before due date
+	}
+
+	// Try absolute date
+	t, err := parseDate(input)
+	if err != nil {
+		return reminder.Alarm{}, fmt.Errorf("invalid alarm: %q — use a duration (15m, 1h, 2d) or a date/time", input)
+	}
+	return reminder.Alarm{AbsoluteDate: &t}, nil
 }
 
 // completeFilter builds the filter for the complete/uncomplete interactive flow.

--- a/cmd/rem/commands/update.go
+++ b/cmd/rem/commands/update.go
@@ -16,6 +16,7 @@ var (
 	updateURL         string
 	updateFlagged     string
 	updateList        string
+	updateRemindMe    string
 	updateInteractive bool
 )
 
@@ -28,6 +29,7 @@ var updateCmd = &cobra.Command{
   rem update abc12345 --notes "Updated notes" --priority medium
   rem edit abc12345 --name "New title"
   rem update abc12345 --list "Work"
+  rem update abc12345 --remind-me 15m
   rem update -i
   rem update -i abc12345`,
 	Args: func(cmd *cobra.Command, args []string) error {
@@ -92,6 +94,17 @@ var updateCmd = &cobra.Command{
 		if cmd.Flags().Changed("list") {
 			updates["list"] = updateList
 		}
+		if cmd.Flags().Changed("remind-me") {
+			if updateRemindMe == "" || updateRemindMe == "none" {
+				updates["alarms"] = nil
+			} else {
+				alarm, err := parseAlarm(updateRemindMe)
+				if err != nil {
+					return err
+				}
+				updates["alarms"] = []reminder.Alarm{alarm}
+			}
+		}
 
 		if len(updates) == 0 {
 			return fmt.Errorf("no updates specified")
@@ -115,6 +128,7 @@ func init() {
 	updateCmd.Flags().StringVarP(&updateURL, "url", "u", "", "New URL")
 	updateCmd.Flags().StringVar(&updateFlagged, "flagged", "", "Set flagged status: true/false")
 	updateCmd.Flags().StringVarP(&updateList, "list", "l", "", "Move reminder to a different list")
+	updateCmd.Flags().StringVar(&updateRemindMe, "remind-me", "", "Set alarm: duration before due (15m, 1h, 2d), 'none' to clear")
 	updateCmd.Flags().BoolVarP(&updateInteractive, "interactive", "i", false, "Update interactively")
 
 	rootCmd.AddCommand(updateCmd)

--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -9,22 +9,40 @@ import (
 	"github.com/BRO3886/rem/internal/reminder"
 )
 
+// JSONAlarm is the JSON-serializable representation of an alarm.
+type JSONAlarm struct {
+	AbsoluteDate   *string `json:"absolute_date,omitempty"`
+	RelativeOffset string  `json:"relative_offset,omitempty"` // e.g., "-15m0s"
+	Description    string  `json:"description"`               // human-readable
+}
+
+// JSONRecurrenceRule is the JSON-serializable representation of a recurrence rule.
+type JSONRecurrenceRule struct {
+	Description string   `json:"description"` // human-readable
+	Frequency   string   `json:"frequency"`   // daily, weekly, monthly, yearly
+	Interval    int      `json:"interval"`
+	DaysOfWeek  []string `json:"days_of_week,omitempty"`
+}
+
 // JSONReminder is the JSON-serializable representation of a reminder.
 type JSONReminder struct {
-	ID               string  `json:"id"`
-	Name             string  `json:"name"`
-	Body             string  `json:"body,omitempty"`
-	ListName         string  `json:"list_name"`
-	DueDate          *string `json:"due_date,omitempty"`
-	RemindMeDate     *string `json:"remind_me_date,omitempty"`
-	CompletionDate   *string `json:"completion_date,omitempty"`
-	CreationDate     *string `json:"creation_date,omitempty"`
-	ModificationDate *string `json:"modification_date,omitempty"`
-	Priority         int     `json:"priority"`
-	PriorityLabel    string  `json:"priority_label"`
-	Flagged          bool    `json:"flagged"`
-	Completed        bool    `json:"completed"`
-	URL              string  `json:"url,omitempty"`
+	ID               string               `json:"id"`
+	Name             string               `json:"name"`
+	Body             string               `json:"body,omitempty"`
+	ListName         string               `json:"list_name"`
+	DueDate          *string              `json:"due_date,omitempty"`
+	RemindMeDate     *string              `json:"remind_me_date,omitempty"`
+	CompletionDate   *string              `json:"completion_date,omitempty"`
+	CreationDate     *string              `json:"creation_date,omitempty"`
+	ModificationDate *string              `json:"modification_date,omitempty"`
+	Priority         int                  `json:"priority"`
+	PriorityLabel    string               `json:"priority_label"`
+	Flagged          bool                 `json:"flagged"`
+	Completed        bool                 `json:"completed"`
+	URL              string               `json:"url,omitempty"`
+	Recurring        bool                 `json:"recurring,omitempty"`
+	RecurrenceRules  []JSONRecurrenceRule `json:"recurrence_rules,omitempty"`
+	Alarms           []JSONAlarm          `json:"alarms,omitempty"`
 }
 
 const timeFormat = "2006-01-02T15:04:05"
@@ -37,9 +55,24 @@ func formatTimePtr(t *time.Time) *string {
 	return &s
 }
 
+func frequencyString(f reminder.RecurrenceFrequency) string {
+	switch f {
+	case reminder.FrequencyDaily:
+		return "daily"
+	case reminder.FrequencyWeekly:
+		return "weekly"
+	case reminder.FrequencyMonthly:
+		return "monthly"
+	case reminder.FrequencyYearly:
+		return "yearly"
+	default:
+		return "unknown"
+	}
+}
+
 // ToJSON converts a reminder to its JSON representation.
 func ToJSON(r *reminder.Reminder) JSONReminder {
-	return JSONReminder{
+	jr := JSONReminder{
 		ID:               r.ID,
 		Name:             r.Name,
 		Body:             r.Body,
@@ -54,7 +87,31 @@ func ToJSON(r *reminder.Reminder) JSONReminder {
 		Flagged:          r.Flagged,
 		Completed:        r.Completed,
 		URL:              r.URL,
+		Recurring:        r.Recurring,
 	}
+
+	for _, rule := range r.RecurrenceRules {
+		jr.RecurrenceRules = append(jr.RecurrenceRules, JSONRecurrenceRule{
+			Description: rule.String(),
+			Frequency:   frequencyString(rule.Frequency),
+			Interval:    rule.Interval,
+			DaysOfWeek:  rule.DaysOfWeek,
+		})
+	}
+
+	for _, a := range r.Alarms {
+		ja := JSONAlarm{
+			Description: a.String(),
+		}
+		if a.AbsoluteDate != nil {
+			ja.AbsoluteDate = formatTimePtr(a.AbsoluteDate)
+		} else {
+			ja.RelativeOffset = a.RelativeOffset.String()
+		}
+		jr.Alarms = append(jr.Alarms, ja)
+	}
+
+	return jr
 }
 
 // ExportJSON writes reminders as JSON to the writer.

--- a/internal/reminder/model.go
+++ b/internal/reminder/model.go
@@ -1,6 +1,10 @@
 package reminder
 
-import "time"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
 
 // Priority represents the priority level of a reminder.
 type Priority int
@@ -41,6 +45,95 @@ func ParsePriority(s string) Priority {
 	}
 }
 
+// Alarm represents a reminder notification alert.
+type Alarm struct {
+	AbsoluteDate   *time.Time
+	RelativeOffset time.Duration // negative = before due date
+}
+
+// FormatAlarm returns a human-readable description of the alarm.
+func (a Alarm) String() string {
+	if a.AbsoluteDate != nil {
+		return a.AbsoluteDate.Local().Format("Mon Jan 02, 2006 at 3:04 PM")
+	}
+	d := a.RelativeOffset
+	if d == 0 {
+		return "at time of event"
+	}
+	// RelativeOffset is negative (before due date)
+	if d < 0 {
+		d = -d
+	}
+	switch {
+	case d < time.Hour:
+		return fmt.Sprintf("%d minutes before", int(d.Minutes()))
+	case d < 24*time.Hour:
+		h := int(d.Hours())
+		if h == 1 {
+			return "1 hour before"
+		}
+		return fmt.Sprintf("%d hours before", h)
+	default:
+		days := int(d.Hours() / 24)
+		if days == 1 {
+			return "1 day before"
+		}
+		return fmt.Sprintf("%d days before", days)
+	}
+}
+
+// RecurrenceFrequency defines how often a reminder repeats.
+type RecurrenceFrequency int
+
+const (
+	FrequencyDaily   RecurrenceFrequency = 0
+	FrequencyWeekly  RecurrenceFrequency = 1
+	FrequencyMonthly RecurrenceFrequency = 2
+	FrequencyYearly  RecurrenceFrequency = 3
+)
+
+// RecurrenceRule defines how a reminder repeats.
+type RecurrenceRule struct {
+	Frequency  RecurrenceFrequency
+	Interval   int
+	DaysOfWeek []string // e.g., ["Mon", "Wed", "Fri"]
+}
+
+// FormatRecurrence returns a human-readable recurrence description.
+func (r RecurrenceRule) String() string {
+	freq := ""
+	switch r.Frequency {
+	case FrequencyDaily:
+		if r.Interval == 1 {
+			freq = "every day"
+		} else {
+			freq = fmt.Sprintf("every %d days", r.Interval)
+		}
+	case FrequencyWeekly:
+		if r.Interval == 1 {
+			freq = "every week"
+		} else {
+			freq = fmt.Sprintf("every %d weeks", r.Interval)
+		}
+	case FrequencyMonthly:
+		if r.Interval == 1 {
+			freq = "every month"
+		} else {
+			freq = fmt.Sprintf("every %d months", r.Interval)
+		}
+	case FrequencyYearly:
+		if r.Interval == 1 {
+			freq = "every year"
+		} else {
+			freq = fmt.Sprintf("every %d years", r.Interval)
+		}
+	}
+	if len(r.DaysOfWeek) > 0 {
+		freq += " on " + strings.Join(r.DaysOfWeek, ", ")
+	}
+	return freq
+}
+
 // Reminder represents a single reminder item.
 type Reminder struct {
 	ID               string
@@ -57,6 +150,10 @@ type Reminder struct {
 	Flagged          bool
 	Completed        bool
 	URL              string // stored in body, extracted for convenience
+	Recurring        bool
+	RecurrenceRules  []RecurrenceRule
+	HasAlarms        bool
+	Alarms           []Alarm
 }
 
 // List represents a Reminders list.

--- a/internal/reminder/model.go
+++ b/internal/reminder/model.go
@@ -66,7 +66,11 @@ func (a Alarm) String() string {
 	}
 	switch {
 	case d < time.Hour:
-		return fmt.Sprintf("%d minutes before", int(d.Minutes()))
+		m := int(d.Minutes())
+		if m == 1 {
+			return "1 minute before"
+		}
+		return fmt.Sprintf("%d minutes before", m)
 	case d < 24*time.Hour:
 		h := int(d.Hours())
 		if h == 1 {

--- a/internal/service/reminders.go
+++ b/internal/service/reminders.go
@@ -47,6 +47,13 @@ func (s *ReminderService) CreateReminder(r *reminder.Reminder) (string, error) {
 		input.URL = r.URL
 	}
 
+	for _, a := range r.Alarms {
+		input.Alarms = append(input.Alarms, reminders.Alarm{
+			AbsoluteDate:   a.AbsoluteDate,
+			RelativeOffset: a.RelativeOffset,
+		})
+	}
+
 	created, err := s.client.CreateReminder(input)
 	if err != nil {
 		return "", fmt.Errorf("failed to create reminder: %w", err)
@@ -241,6 +248,21 @@ func (s *ReminderService) UpdateReminder(id string, updates map[string]any) erro
 		case "list":
 			v := value.(string)
 			input.ListName = &v
+		case "alarms":
+			if value == nil {
+				empty := []reminders.Alarm{}
+				input.Alarms = &empty
+			} else {
+				alarms := value.([]reminder.Alarm)
+				ekAlarms := make([]reminders.Alarm, len(alarms))
+				for i, a := range alarms {
+					ekAlarms[i] = reminders.Alarm{
+						AbsoluteDate:   a.AbsoluteDate,
+						RelativeOffset: a.RelativeOffset,
+					}
+				}
+				input.Alarms = &ekAlarms
+			}
 		}
 	}
 
@@ -248,7 +270,8 @@ func (s *ReminderService) UpdateReminder(id string, updates map[string]any) erro
 	hasEventKitUpdates := input.Title != nil || input.Notes != nil ||
 		input.DueDate != nil || input.ClearDueDate ||
 		input.RemindMeDate != nil || input.Priority != nil ||
-		input.Completed != nil || input.URL != nil || input.ListName != nil
+		input.Completed != nil || input.URL != nil || input.ListName != nil ||
+		input.Alarms != nil
 
 	if hasEventKitUpdates {
 		if _, err := s.client.UpdateReminder(id, input); err != nil {
@@ -302,6 +325,12 @@ func (s *ReminderService) DeleteReminder(id string) error {
 	return nil
 }
 
+// DeleteReminders deletes multiple reminders in a single batch call.
+// Returns a map of reminder ID to error for any that failed.
+func (s *ReminderService) DeleteReminders(ids []string) map[string]error {
+	return s.client.DeleteReminders(ids)
+}
+
 // CompleteReminder marks a reminder as completed.
 func (s *ReminderService) CompleteReminder(id string) error {
 	if _, err := s.client.CompleteReminder(id); err != nil {
@@ -344,6 +373,28 @@ func fromEventKitReminder(r *reminders.Reminder) *reminder.Reminder {
 		Completed:        r.Completed,
 		Flagged:          r.Flagged,
 		URL:              r.URL,
+		Recurring:        r.Recurring,
+		HasAlarms:        r.HasAlarms,
+	}
+
+	// Map recurrence rules
+	for _, rule := range r.RecurrenceRules {
+		rr := reminder.RecurrenceRule{
+			Frequency: reminder.RecurrenceFrequency(rule.Frequency),
+			Interval:  rule.Interval,
+		}
+		for _, dow := range rule.DaysOfTheWeek {
+			rr.DaysOfWeek = append(rr.DaysOfWeek, dow.DayOfTheWeek.String())
+		}
+		result.RecurrenceRules = append(result.RecurrenceRules, rr)
+	}
+
+	// Map alarms
+	for _, a := range r.Alarms {
+		result.Alarms = append(result.Alarms, reminder.Alarm{
+			AbsoluteDate:   a.AbsoluteDate,
+			RelativeOffset: a.RelativeOffset,
+		})
 	}
 
 	// For backwards compatibility: if URL is empty but notes contain a URL, extract it

--- a/internal/ui/output.go
+++ b/internal/ui/output.go
@@ -201,6 +201,22 @@ func printReminderRichDetail(w io.Writer, r *reminder.Reminder) {
 		fmt.Fprintf(w, "%s %s\n", bold("Flagged:"), yellow("yes"))
 	}
 
+	if r.Recurring && len(r.RecurrenceRules) > 0 {
+		rules := make([]string, len(r.RecurrenceRules))
+		for i, rule := range r.RecurrenceRules {
+			rules[i] = rule.String()
+		}
+		fmt.Fprintf(w, "%s %s\n", bold("Repeats:"), cyan(strings.Join(rules, "; ")))
+	}
+
+	if r.HasAlarms && len(r.Alarms) > 0 {
+		alarms := make([]string, len(r.Alarms))
+		for i, a := range r.Alarms {
+			alarms[i] = a.String()
+		}
+		fmt.Fprintf(w, "%s %s\n", bold("Alarms:"), strings.Join(alarms, ", "))
+	}
+
 	if r.CreationDate != nil {
 		fmt.Fprintf(w, "%s %s\n", bold("Created:"), r.CreationDate.Local().Format("Mon Jan 02, 2006 at 3:04 PM"))
 	}
@@ -230,6 +246,20 @@ func printReminderPlainDetail(w io.Writer, r *reminder.Reminder) {
 	}
 	if r.Flagged {
 		fmt.Fprintf(w, "Flagged: yes\n")
+	}
+	if r.Recurring && len(r.RecurrenceRules) > 0 {
+		rules := make([]string, len(r.RecurrenceRules))
+		for i, rule := range r.RecurrenceRules {
+			rules[i] = rule.String()
+		}
+		fmt.Fprintf(w, "Repeats: %s\n", strings.Join(rules, "; "))
+	}
+	if r.HasAlarms && len(r.Alarms) > 0 {
+		alarms := make([]string, len(r.Alarms))
+		for i, a := range r.Alarms {
+			alarms[i] = a.String()
+		}
+		fmt.Fprintf(w, "Alarms: %s\n", strings.Join(alarms, ", "))
 	}
 }
 
@@ -272,6 +302,9 @@ func statusString(r *reminder.Reminder) string {
 	}
 	if r.Flagged {
 		parts = append(parts, "flagged")
+	}
+	if r.Recurring {
+		parts = append(parts, "recurring")
 	}
 	if len(parts) == 0 {
 		return "-"

--- a/skills/rem-cli/SKILL.md
+++ b/skills/rem-cli/SKILL.md
@@ -194,6 +194,7 @@ See [go-eventkit docs](https://github.com/BRO3886/go-eventkit) for the full API 
 ## Limitations
 
 - **macOS only** — requires EventKit framework and `osascript`
-- **No tags, subtasks, or recurrence** — not exposed by EventKit/AppleScript
+- **No tags or subtasks** — not exposed by EventKit/AppleScript
+- **Recurrence is read-only** — displayed in `rem show` but cannot be created/modified via CLI
 - **`--flagged` filter is slower** (~3-4s) — falls back to JXA since EventKit doesn't expose flagged
 - **List deletion** may fail on some macOS versions

--- a/skills/rem-cli/references/commands.md
+++ b/skills/rem-cli/references/commands.md
@@ -8,6 +8,7 @@ Create a new reminder.
 rem add "Buy groceries" --list Personal --due tomorrow --priority high
 rem add "Review PR" --due "next friday at 2pm" --url https://github.com/org/repo/pull/123
 rem add "Call dentist" --notes "Ask about cleaning"
+rem add "Meeting" --due "tomorrow at 10am" --remind-me 15m
 rem add -i   # Interactive mode
 ```
 
@@ -19,6 +20,7 @@ rem add -i   # Interactive mode
 | `--notes` | `-n` | Notes/body text | Empty |
 | `--url` | `-u` | URL to attach (stored in body) | None |
 | `--flagged` | `-f` | Flag the reminder | false |
+| `--remind-me` | — | Set alarm: duration before due (15m, 1h, 2d) or absolute time | None |
 | `--interactive` | `-i` | Create interactively | false |
 
 Aliases: `create`, `new`
@@ -82,6 +84,7 @@ rem update abc12345 --name "New title"
 rem update abc12345 --due none    # Clear due date
 rem update abc12345 --flagged true
 rem update abc12345 --list "Work"  # Move to a different list
+rem update abc12345 --remind-me 15m
 rem update abc12345 -i            # Interactive mode
 ```
 
@@ -94,6 +97,7 @@ rem update abc12345 -i            # Interactive mode
 | `--priority` | `-p` | New priority: high, medium, low, none | — |
 | `--url` | `-u` | New URL | — |
 | `--flagged` | — | Set flagged: true/false | — |
+| `--remind-me` | — | Set alarm: duration (15m, 1h, 2d), 'none' to clear | — |
 | `--interactive` | `-i` | Update interactively | false |
 
 Aliases: `edit`
@@ -102,10 +106,11 @@ Aliases: `edit`
 
 ## rem delete
 
-Delete a reminder. Prompts for confirmation unless `--force` is used.
+Delete one or more reminders. Supports multiple IDs for batch deletion. Prompts for confirmation unless `--force` is used.
 
 ```bash
 rem delete abc12345
+rem delete abc12345 def67890 --force
 rem rm abc12345 --force
 ```
 

--- a/website/content/docs/commands.md
+++ b/website/content/docs/commands.md
@@ -46,6 +46,7 @@ rem add "Buy groceries" --due tomorrow --priority high --list Personal
 | `-n, --notes` | Notes/body text |
 | `-u, --url` | URL to attach (stored in body) |
 | `-f, --flagged` | Flag the reminder |
+| `--remind-me` | Set alarm: duration before due (`15m`, `1h`, `2d`) or absolute time |
 | `-i, --interactive` | Step-by-step interactive creation |
 
 ### `rem list`
@@ -70,7 +71,7 @@ rem list --list Work --incomplete --due-before 2026-03-01
 
 ### `rem show`
 
-Show full details for a single reminder.
+Show full details for a single reminder, including alarms and recurrence rules.
 
 ```bash
 rem show 6ECE
@@ -99,6 +100,7 @@ rem update 6ECE --priority medium --due "next friday"
 | `-n, --notes` | New notes |
 | `-u, --url` | New URL |
 | `--flagged` | Set flag: `true` or `false` |
+| `--remind-me` | Set alarm: duration (`15m`, `1h`, `2d`), `none` to clear |
 | `-i, --interactive` | Interactive update |
 
 ### `rem complete`
@@ -130,11 +132,11 @@ rem unflag 6ECE
 
 ### `rem delete`
 
-Delete a reminder.
+Delete one or more reminders. Supports multiple IDs for batch deletion.
 
 ```bash
 rem delete 6ECE
-rem delete 6ECE --force    # skip confirmation
+rem delete 6ECE A1B2 --force    # batch delete, skip confirmation
 ```
 
 **Aliases:** `rm`, `remove`


### PR DESCRIPTION
## Summary
- Add alarm support: `--remind-me` flag on `rem add` and `rem update` (relative offsets like `15m`, `1h`, `2d` or absolute times)
- Display alarms and recurrence rules in `rem show` output (rich, plain, and JSON)
- Add batch delete: `rem delete id1 id2 id3` using go-eventkit's `DeleteReminders` API
- Show "recurring" indicator in table list view status column
- Include alarm and recurrence data in JSON export

## New Capabilities
- **Alarms**: `rem add "Meeting" --due "tomorrow at 10am" --remind-me 15m`
- **Alarm update**: `rem update abc123 --remind-me 1h` (or `--remind-me none` to clear)
- **Batch delete**: `rem delete abc123 def456 ghi789 --force`
- **Recurrence display**: recurring reminders show pattern in `rem show` (e.g., "every week on Mon, Wed")

## Test plan
- [x] `go test ./...` — all packages pass
- [x] `make build` — compiles cleanly
- [x] Smoke tested `rem add` with `--remind-me 15m` — alarm created and visible in `rem show`
- [x] Smoke tested `rem update --remind-me 1h` — alarm updated correctly
- [x] Smoke tested batch delete with 3 IDs — all deleted in single call
- [x] JSON output includes alarm data with human-readable descriptions

Partial fix for #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)
