### PR TITLE
Preserve alarms during JSON import roundtrip

### DIFF
--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -159,6 +159,22 @@ func ImportJSON(r io.Reader) ([]*reminder.Reminder, error) {
 			}
 		}
 
+		for _, ja := range jr.Alarms {
+			a := reminder.Alarm{}
+			if ja.AbsoluteDate != nil {
+				t, err := time.ParseInLocation(timeFormat, *ja.AbsoluteDate, time.Now().Location())
+				if err == nil {
+					a.AbsoluteDate = &t
+				}
+			} else if ja.RelativeOffset != "" {
+				d, err := time.ParseDuration(ja.RelativeOffset)
+				if err == nil {
+					a.RelativeOffset = d
+				}
+			}
+			rem.Alarms = append(rem.Alarms, a)
+		}
+
 		reminders = append(reminders, rem)
 	}
 


### PR DESCRIPTION
## Summary
- Fix `ImportJSON` to parse alarm data (absolute dates and relative offsets) from exported JSON
- Previously, `rem export` → `rem import` roundtrip silently dropped alarms

## Test plan
- [x] `go test ./...` — all packages pass
- [x] `make build` — compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
