### PR TITLE
Comprehensive documentation update for v0.4.0 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A blazing fast CLI for macOS Reminders. Sub-200ms reads AND writes via EventKit,
 - **Sub-200ms reads AND writes** — EventKit via cgo (go-eventkit), direct memory access, no IPC
 - **Single binary** — EventKit compiled in via cgo, no helper processes
 - **Natural language dates** — `tomorrow`, `next friday at 2pm`, `in 3 hours`, `eod`
-- **19 commands** — full CRUD, search, stats, overdue, upcoming, interactive mode
+- **20 commands** — full CRUD, search, stats, overdue, upcoming, interactive mode
 - **Multiple output formats** — table, JSON, plain text
 - **Import/Export** — JSON and CSV with full property round-trip
 - **Powered by [go-eventkit](https://github.com/BRO3886/go-eventkit)** — use the same library directly for programmatic Go access
@@ -95,7 +95,7 @@ rem stats
 
 ```bash
 # Create
-rem add "Title" [--list LIST] [--due DATE] [--priority high|medium|low] [--notes TEXT] [--url URL] [--flagged]
+rem add "Title" [--list LIST] [--due DATE] [--priority high|medium|low] [--notes TEXT] [--url URL] [--flagged] [--remind-me DURATION]
 rem add -i                          # Interactive creation
 
 # List
@@ -107,7 +107,7 @@ rem show <id>                       # Full or partial ID
 rem get <id> -o json
 
 # Update
-rem update <id> [--name TEXT] [--due DATE] [--priority LEVEL] [--notes TEXT] [--url URL]
+rem update <id> [--name TEXT] [--due DATE] [--priority LEVEL] [--notes TEXT] [--url URL] [--remind-me DURATION] [--list LIST]
 
 # Complete / Uncomplete
 rem complete <id>
@@ -118,9 +118,12 @@ rem uncomplete <id>
 rem flag <id>
 rem unflag <id>
 
-# Delete
-rem delete <id>                     # Asks for confirmation
+# Delete (supports multiple IDs)
+rem delete <id> [id2 id3...]        # Asks for confirmation
 rem rm <id> --force                 # Skip confirmation
+
+# Today — due and overdue reminders
+rem today
 ```
 
 ### Lists

--- a/skills/rem-cli/SKILL.md
+++ b/skills/rem-cli/SKILL.md
@@ -9,7 +9,7 @@ compatibility: Requires macOS with Reminders.app. Requires Xcode Command Line To
 
 # rem — CLI for macOS Reminders
 
-A Go CLI that wraps macOS Reminders. Sub-200ms reads via cgo + EventKit. Single binary, no dependencies at runtime.
+A Go CLI that wraps macOS Reminders. Sub-200ms reads AND writes via cgo + EventKit. Single binary, no dependencies at runtime.
 
 ## Installation
 
@@ -84,6 +84,7 @@ rem stats
 |---------|-------------|
 | `rem search <query>` | Search title and notes |
 | `rem stats` | Show statistics and per-list breakdown |
+| `rem today` | Show today's due and overdue reminders |
 | `rem overdue` | Show overdue reminders |
 | `rem upcoming` | Show reminders due in next N days (default: 7) |
 
@@ -147,7 +148,7 @@ The `NO_COLOR` environment variable is respected.
 
 ### URL Storage
 
-macOS Reminders has no native URL field. rem stores URLs in the notes/body field with a `URL: ` prefix and extracts them for display.
+URLs are stored natively via EventKit's URL field (go-eventkit v0.4.0+). For backwards compatibility, rem also extracts URLs from the notes/body field if the native field is empty.
 
 ## Common Workflows
 

--- a/skills/rem-cli/references/commands.md
+++ b/skills/rem-cli/references/commands.md
@@ -257,17 +257,36 @@ Output includes: total, completed, incomplete, flagged, overdue counts, completi
 
 ---
 
+## rem today
+
+Show today's due and overdue reminders (incomplete with due date up to end of today).
+
+```bash
+rem today
+rem today --list Work
+rem today -o json
+```
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--list` | `-l` | Filter by list name | All lists |
+| `--output` | `-o` | Output format: table, json, plain | table |
+
+---
+
 ## rem overdue
 
 Show overdue reminders (incomplete with due date in the past).
 
 ```bash
 rem overdue
+rem overdue --list Work
 rem overdue -o json
 ```
 
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
+| `--list` | `-l` | Filter by list name | All lists |
 | `--output` | `-o` | Output format: table, json, plain | table |
 
 ---
@@ -279,12 +298,14 @@ Show upcoming reminders (due in the next N days).
 ```bash
 rem upcoming
 rem upcoming --days 14
+rem upcoming --list Work
 rem upcoming -o json
 ```
 
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
 | `--days` | — | Number of days to look ahead | 7 |
+| `--list` | `-l` | Filter by list name | All lists |
 | `--output` | `-o` | Output format: table, json, plain | table |
 
 ---

--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -8,7 +8,7 @@ description: "Complete documentation for the rem CLI tool."
 Welcome to the rem documentation. Choose a section below to get started.
 
 - [Getting Started](/docs/getting-started/) — Installation, setup, and your first commands
-- [Commands](/docs/commands/) — Complete reference for all 19 commands
+- [Commands](/docs/commands/) — Complete reference for all 20 commands
 - [Architecture](/docs/architecture/) — How rem works under the hood
 - [Go API](/docs/api/) — Using rem as a Go library
 - [Performance](/docs/performance/) — Benchmarks and optimization story

--- a/website/content/docs/commands.md
+++ b/website/content/docs/commands.md
@@ -1,6 +1,6 @@
 ---
 title: "Commands"
-description: "Complete reference for all 19 rem CLI commands: rem add, rem list, rem complete, rem delete, rem update, rem search, rem stats, rem overdue, rem upcoming, rem export, rem import, rem interactive, rem lists, rem list-mgmt, rem flag, rem skills, and more."
+description: "Complete reference for all 20 rem CLI commands: rem add, rem list, rem complete, rem delete, rem update, rem search, rem stats, rem today, rem overdue, rem upcoming, rem export, rem import, rem interactive, rem lists, rem list-mgmt, rem flag, rem skills, and more."
 keywords:
   - rem CLI commands reference
   - rem add reminder terminal
@@ -170,13 +170,31 @@ rem stats
 
 Displays: total count, completed, incomplete, flagged, overdue, completion rate, and per-list breakdown.
 
+### `rem today`
+
+Show today's due and overdue reminders.
+
+```bash
+rem today
+rem today --list Work
+```
+
+| Flag | Description |
+|------|-------------|
+| `-l, --list` | Filter by list name |
+
 ### `rem overdue`
 
 Show all overdue incomplete reminders.
 
 ```bash
 rem overdue
+rem overdue --list Work
 ```
+
+| Flag | Description |
+|------|-------------|
+| `-l, --list` | Filter by list name |
 
 ### `rem upcoming`
 
@@ -190,6 +208,7 @@ rem upcoming --days 14 # next 14 days
 | Flag | Description |
 |------|-------------|
 | `--days` | Number of days to look ahead (default: 7) |
+| `-l, --list` | Filter by list name |
 
 ## Lists
 

--- a/website/content/docs/getting-started.md
+++ b/website/content/docs/getting-started.md
@@ -143,6 +143,6 @@ rem skills install --agent all       # All supported agents
 
 ## What's next
 
-- [Commands](/docs/commands/) — Full reference for all 19 commands
+- [Commands](/docs/commands/) — Full reference for all 20 commands
 - [Architecture](/docs/architecture/) — How rem works under the hood
 - [Go API](/docs/api/) — Use rem as a library in your Go programs

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -26,21 +26,22 @@ sudo mv rem /usr/local/bin/rem
 # Use rem-darwin-amd64.tar.gz for Intel Macs
 
 
-## Commands (all 19)
+## Commands (all 20)
 
-rem add "title" [--due DATE] [--priority high|medium|low|none] [--list NAME] [--notes TEXT] [--url URL] [--flagged] [-i]
+rem add "title" [--due DATE] [--priority high|medium|low|none] [--list NAME] [--notes TEXT] [--url URL] [--flagged] [--remind-me DURATION] [-i]
 rem list [--list NAME] [--incomplete] [--completed] [--flagged] [--due-before DATE] [--due-after DATE] [-s QUERY]
 rem show ID
-rem update ID [--name TEXT] [--due DATE] [--priority LEVEL] [--notes TEXT] [--url URL] [--flagged true|false] [-i]
+rem update ID [--name TEXT] [--due DATE] [--priority LEVEL] [--notes TEXT] [--url URL] [--flagged true|false] [--remind-me DURATION] [--list NAME] [-i]
 rem complete ID
 rem uncomplete ID
 rem flag ID
 rem unflag ID
-rem delete ID [--force]
+rem delete ID [ID2 ID3...] [--force]
 rem search QUERY [--list NAME] [--incomplete]
 rem stats
-rem overdue
-rem upcoming [--days N]
+rem today [--list NAME]
+rem overdue [--list NAME]
+rem upcoming [--days N] [--list NAME]
 rem lists [--count]
 rem list-mgmt create NAME
 rem list-mgmt rename OLD NEW
@@ -58,12 +59,13 @@ Global flags: -o table|json|plain, --no-color, -h
 
 ## Natural Language Date Formats
 
-rem understands these date patterns (used with --due and --remind):
-- Relative: "in 2 days", "in 3 hours", "in 30 minutes"
-- Named: "today", "tomorrow", "yesterday"
-- Day of week: "next monday", "next friday"
-- Special: "eod" (5pm today), "eow" (Friday 5pm), "next week", "next month"
-- Compound: "next friday at 2pm", "tomorrow at 3:30pm"
+rem understands these date patterns (used with --due and --remind-me):
+- Relative: "in 2 days", "in 3 hours", "in 30 minutes", "5 days ago"
+- Named: "now", "today", "tomorrow", "yesterday"
+- Day of week: "monday", "next monday", "next friday", "monday 2pm"
+- Special: "eod" (5pm today), "eow" (Friday 5pm), "this week", "next week" (next Monday), "next month" (1st of next month)
+- Compound: "next friday at 2pm", "tomorrow at 3:30pm", "today 5pm"
+- Month-day: "mar 15", "21 march", "december 31 11:59pm"
 - Time only: "5pm", "17:00", "3:30pm"
 - ISO 8601: "2026-02-15", "2026-02-15T14:30:00"
 - US format: "02/15/2026", "2/15"
@@ -72,7 +74,7 @@ rem understands these date patterns (used with --due and --remind):
 
 ## Architecture
 
-rem uses go-eventkit (github.com/BRO3886/go-eventkit v0.2.1) for ALL reads and writes:
+rem uses go-eventkit (github.com/BRO3886/go-eventkit v0.4.0) for ALL reads and writes:
 - Reminder CRUD: create, read, update, delete, complete/uncomplete via EventKit
 - List CRUD: create, rename, delete via EventKit
 - Performance: <200ms for all EventKit operations

--- a/website/themes/rem-docs/layouts/index.html
+++ b/website/themes/rem-docs/layouts/index.html
@@ -286,7 +286,7 @@ sudo mv rem /usr/local/bin/rem</code>
       <details class="faq-item scroll-reveal">
         <summary class="faq-question">Does rem work with iCloud Reminders?</summary>
         <div class="faq-answer">
-          <p>Yes. rem accesses whatever is synced to your local macOS Reminders store — including iCloud lists, local lists, and any other accounts you have configured in Reminders.app. All 19 commands work across all lists regardless of their sync source.</p>
+          <p>Yes. rem accesses whatever is synced to your local macOS Reminders store — including iCloud lists, local lists, and any other accounts you have configured in Reminders.app. All 20 commands work across all lists regardless of their sync source.</p>
         </div>
       </details>
 
@@ -307,7 +307,7 @@ sudo mv rem /usr/local/bin/rem</code>
       <details class="faq-item scroll-reveal">
         <summary class="faq-question">How do I add rem to an AI coding agent?</summary>
         <div class="faq-answer">
-          <p>Run <code>rem skills install</code> to copy the embedded agent skill to your agent's skill directory. Supports Claude Code (<code>~/.claude/skills/</code>), Codex CLI (<code>~/.agents/skills/</code>), and OpenClaw (<code>~/.openclaw/skills/</code>). The skill teaches the agent all 19 commands, date formats, and output options.</p>
+          <p>Run <code>rem skills install</code> to copy the embedded agent skill to your agent's skill directory. Supports Claude Code (<code>~/.claude/skills/</code>), Codex CLI (<code>~/.agents/skills/</code>), and OpenClaw (<code>~/.openclaw/skills/</code>). The skill teaches the agent all 20 commands, date formats, and output options.</p>
         </div>
       </details>
 


### PR DESCRIPTION
## Summary
Comprehensive documentation audit and update covering all changes from this session (PRs #14, #16, #17) plus pre-existing gaps.

- Add `today` command to all command references — was added in code but never documented
- Add `--list` flag to `overdue` and `upcoming` in all references
- Add `--remind-me` flag to `add`/`update` in README command section
- Add batch delete syntax to README and llms-full.txt
- Update command count 19 → 20 across 8 files
- Update go-eventkit version reference v0.2.1 → v0.4.0 in llms-full.txt
- Update date patterns in llms-full.txt with all new patterns from dateparser migration
- Fix stale "no native URL field" note in SKILL.md
- Fix "Sub-200ms reads" → "reads AND writes" in SKILL.md

## Test plan
- [x] `make build` — compiles cleanly
- [x] `go test ./...` — all pass
- [x] Grep verified no remaining "19 commands" references in non-journal files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
