### PR TITLE
Add --yes/-y alias for --force on delete commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ rem unflag <id>
 
 # Delete (supports multiple IDs)
 rem delete <id> [id2 id3...]        # Asks for confirmation
-rem rm <id> --force                 # Skip confirmation
+rem rm <id> --force                 # Skip confirmation (--yes / -y also work)
 
 # Today — due and overdue reminders
 rem today

--- a/cmd/rem/commands/delete.go
+++ b/cmd/rem/commands/delete.go
@@ -61,7 +61,7 @@ var deleteCmd = &cobra.Command{
 					return nil
 				}
 			} else {
-				return fmt.Errorf("use --force to delete non-interactively, or run in a terminal")
+				return fmt.Errorf("use --force/-y to delete non-interactively, or run in a terminal")
 			}
 		}
 
@@ -87,7 +87,8 @@ var deleteCmd = &cobra.Command{
 }
 
 func init() {
-	deleteCmd.Flags().BoolVar(&deleteForce, "force", false, "Skip confirmation prompt")
+	deleteCmd.Flags().BoolVarP(&deleteForce, "force", "y", false, "Skip confirmation prompt")
+	deleteCmd.Flags().BoolVar(&deleteForce, "yes", false, "Skip confirmation prompt (alias for --force)")
 	deleteCmd.Flags().BoolVarP(&deleteInteractive, "interactive", "i", false, "Select reminders interactively")
 	deleteCmd.Flags().StringVarP(&deleteList, "list", "l", "", "Filter by list name")
 	deleteCmd.Flags().BoolVar(&deleteFlagged, "flagged", false, "Filter to flagged reminders only")

--- a/cmd/rem/commands/lists.go
+++ b/cmd/rem/commands/lists.go
@@ -122,7 +122,7 @@ var listDeleteCmd = &cobra.Command{
 					return nil
 				}
 			} else {
-				return fmt.Errorf("use --force to delete non-interactively, or run in a terminal")
+				return fmt.Errorf("use --force/-y to delete non-interactively, or run in a terminal")
 			}
 		}
 
@@ -152,7 +152,8 @@ func init() {
 	listCreateCmd.Flags().BoolVarP(&listCreateInteractive, "interactive", "i", false, "Create list interactively")
 	listRenameCmd.Flags().BoolVarP(&listRenameInteractive, "interactive", "i", false, "Rename list interactively")
 	listDeleteCmd.Flags().BoolVarP(&listDeleteInteractive, "interactive", "i", false, "Delete list interactively")
-	listDeleteCmd.Flags().BoolVar(&listDeleteForce, "force", false, "Skip confirmation prompt")
+	listDeleteCmd.Flags().BoolVarP(&listDeleteForce, "force", "y", false, "Skip confirmation prompt")
+	listDeleteCmd.Flags().BoolVar(&listDeleteForce, "yes", false, "Skip confirmation prompt (alias for --force)")
 
 	listMgmtCmd.AddCommand(listCreateCmd)
 	listMgmtCmd.AddCommand(listRenameCmd)

--- a/skills/rem-cli/references/commands.md
+++ b/skills/rem-cli/references/commands.md
@@ -116,7 +116,7 @@ rem rm abc12345 --force
 
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
-| `--force` | — | Skip confirmation | false |
+| `--force` / `--yes` | `-y` | Skip confirmation | false |
 
 Aliases: `rm`, `remove`
 
@@ -216,7 +216,7 @@ rem lm rm "My List" --force
 
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
-| `--force` | — | Skip confirmation | false |
+| `--force` / `--yes` | `-y` | Skip confirmation | false |
 
 Aliases: `lm rm`
 

--- a/website/content/docs/commands.md
+++ b/website/content/docs/commands.md
@@ -143,7 +143,7 @@ rem delete 6ECE A1B2 --force    # batch delete, skip confirmation
 
 | Flag | Description |
 |------|-------------|
-| `--force` | Skip the confirmation prompt |
+| `--force` / `--yes` / `-y` | Skip the confirmation prompt |
 
 ## Search & Analytics
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -36,7 +36,7 @@ rem complete ID
 rem uncomplete ID
 rem flag ID
 rem unflag ID
-rem delete ID [ID2 ID3...] [--force]
+rem delete ID [ID2 ID3...] [--force/--yes/-y]
 rem search QUERY [--list NAME] [--incomplete]
 rem stats
 rem today [--list NAME]
@@ -45,7 +45,7 @@ rem upcoming [--days N] [--list NAME]
 rem lists [--count]
 rem list-mgmt create NAME
 rem list-mgmt rename OLD NEW
-rem list-mgmt delete NAME [--force]
+rem list-mgmt delete NAME [--force/--yes/-y]
 rem export [--list NAME] [--format json|csv] [--output-file PATH] [--incomplete]
 rem import FILE [--list NAME] [--dry-run]
 rem interactive  (alias: rem i)


### PR DESCRIPTION
## Summary
- Add `--yes` and `-y` as aliases for `--force` on `rem delete` and `rem list-mgmt delete`
- Update error messages to mention `-y` shorthand
- Update all documentation: README, skill references, website commands, llms-full.txt

## Test plan
- [x] `go test ./...` — all pass
- [x] Smoke tested `rem delete <id> --yes` — works
- [x] Smoke tested `rem delete <id> -y` — works
- [x] Existing `--force` flag still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
