### PR TITLE
Add --repeat flag for recurrence creation on add and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ rem stats
 
 ```bash
 # Create
-rem add "Title" [--list LIST] [--due DATE] [--priority high|medium|low] [--notes TEXT] [--url URL] [--flagged] [--remind-me DURATION]
+rem add "Title" [--list LIST] [--due DATE] [--priority high|medium|low] [--notes TEXT] [--url URL] [--flagged] [--remind-me DURATION] [--repeat PATTERN]
 rem add -i                          # Interactive creation
 
 # List
@@ -107,7 +107,7 @@ rem show <id>                       # Full or partial ID
 rem get <id> -o json
 
 # Update
-rem update <id> [--name TEXT] [--due DATE] [--priority LEVEL] [--notes TEXT] [--url URL] [--remind-me DURATION] [--list LIST]
+rem update <id> [--name TEXT] [--due DATE] [--priority LEVEL] [--notes TEXT] [--url URL] [--remind-me DURATION] [--repeat PATTERN] [--list LIST]
 
 # Complete / Uncomplete
 rem complete <id>

--- a/cmd/rem/commands/add.go
+++ b/cmd/rem/commands/add.go
@@ -17,7 +17,8 @@ var (
 	addNotes      string
 	addURL        string
 	addFlagged    bool
-	addRemindMe   string
+	addRemindMe    string
+	addRepeat      string
 	addInteractive bool
 )
 
@@ -30,6 +31,7 @@ var addCmd = &cobra.Command{
   rem add "Review PR" --due "next friday at 2pm" --url https://github.com/org/repo/pull/123
   rem add "Call dentist" --due "in 2 days" --notes "Ask about cleaning"
   rem add "Meeting" --due "tomorrow at 10am" --remind-me 15m
+  rem add "Standup" --due "monday 9am" --repeat "weekly on mon,wed,fri"
   rem add -i  # Interactive mode`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if addInteractive {
@@ -65,6 +67,14 @@ var addCmd = &cobra.Command{
 			r.Alarms = []reminder.Alarm{alarm}
 		}
 
+		if addRepeat != "" {
+			rule, err := parseRecurrence(addRepeat)
+			if err != nil {
+				return err
+			}
+			r.RecurrenceRules = []reminder.RecurrenceRule{rule}
+		}
+
 		id, err := reminderSvc.CreateReminder(r)
 		if err != nil {
 			return err
@@ -89,6 +99,7 @@ func init() {
 	addCmd.Flags().StringVarP(&addURL, "url", "u", "", "URL to attach to the reminder")
 	addCmd.Flags().BoolVarP(&addFlagged, "flagged", "f", false, "Flag the reminder")
 	addCmd.Flags().StringVar(&addRemindMe, "remind-me", "", "Set alarm: duration before due (15m, 1h, 2d) or absolute time")
+	addCmd.Flags().StringVar(&addRepeat, "repeat", "", "Set recurrence: daily, weekly, 'weekly on mon,wed,fri', monthly, yearly")
 	addCmd.Flags().BoolVarP(&addInteractive, "interactive", "i", false, "Create reminder interactively")
 
 	rootCmd.AddCommand(addCmd)

--- a/cmd/rem/commands/filters.go
+++ b/cmd/rem/commands/filters.go
@@ -2,6 +2,9 @@ package commands
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/BRO3886/go-eventkit/dateparser"
@@ -33,6 +36,106 @@ func parseAlarm(input string) (reminder.Alarm, error) {
 		return reminder.Alarm{}, fmt.Errorf("invalid alarm: %q — use a duration (15m, 1h, 2d) or a date/time", input)
 	}
 	return reminder.Alarm{AbsoluteDate: &t}, nil
+}
+
+// weekdayNum maps day name strings to eventkit weekday numbers (1=Sun..7=Sat).
+var weekdayNum = map[string]int{
+	"sun": 1, "sunday": 1,
+	"mon": 2, "monday": 2,
+	"tue": 3, "tuesday": 3,
+	"wed": 4, "wednesday": 4,
+	"thu": 5, "thursday": 5,
+	"fri": 6, "friday": 6,
+	"sat": 7, "saturday": 7,
+}
+
+// weekdayName maps eventkit weekday numbers to short display names.
+var weekdayName = map[int]string{
+	1: "Sun", 2: "Mon", 3: "Tue", 4: "Wed", 5: "Thu", 6: "Fri", 7: "Sat",
+}
+
+var everyNPattern = regexp.MustCompile(`^every\s+(\d+)\s+(day|days|week|weeks|month|months|year|years)$`)
+
+// parseRecurrence parses a recurrence specification into a domain RecurrenceRule.
+// Supported patterns:
+//   - "daily", "every day", "every 2 days"
+//   - "weekly", "every week", "every 2 weeks"
+//   - "weekly on mon,wed,fri"
+//   - "monthly", "every month", "every 2 months"
+//   - "monthly on 1,15" (days of month)
+//   - "yearly", "every year", "every 2 years"
+func parseRecurrence(input string) (reminder.RecurrenceRule, error) {
+	input = strings.TrimSpace(strings.ToLower(input))
+
+	// Split "on" clause: "weekly on mon,wed" → base="weekly", onClause="mon,wed"
+	base, onClause, _ := strings.Cut(input, " on ")
+	base = strings.TrimSpace(base)
+	onClause = strings.TrimSpace(onClause)
+
+	// Parse base frequency and interval
+	var freq reminder.RecurrenceFrequency
+	interval := 1
+
+	switch base {
+	case "daily", "every day":
+		freq = reminder.FrequencyDaily
+	case "weekly", "every week":
+		freq = reminder.FrequencyWeekly
+	case "monthly", "every month":
+		freq = reminder.FrequencyMonthly
+	case "yearly", "every year":
+		freq = reminder.FrequencyYearly
+	default:
+		matches := everyNPattern.FindStringSubmatch(base)
+		if matches == nil {
+			return reminder.RecurrenceRule{}, fmt.Errorf("invalid recurrence: %q — use 'daily', 'weekly', 'monthly', 'yearly', or 'every N days/weeks/months/years'", input)
+		}
+		interval, _ = strconv.Atoi(matches[1])
+		unit := matches[2]
+		switch {
+		case strings.HasPrefix(unit, "day"):
+			freq = reminder.FrequencyDaily
+		case strings.HasPrefix(unit, "week"):
+			freq = reminder.FrequencyWeekly
+		case strings.HasPrefix(unit, "month"):
+			freq = reminder.FrequencyMonthly
+		case strings.HasPrefix(unit, "year"):
+			freq = reminder.FrequencyYearly
+		}
+	}
+
+	rule := reminder.RecurrenceRule{
+		Frequency: freq,
+		Interval:  interval,
+	}
+
+	// Parse "on" clause
+	if onClause != "" {
+		parts := strings.Split(onClause, ",")
+		switch freq {
+		case reminder.FrequencyWeekly:
+			for _, p := range parts {
+				num, ok := weekdayNum[strings.TrimSpace(p)]
+				if !ok {
+					return reminder.RecurrenceRule{}, fmt.Errorf("unknown day: %q — use mon, tue, wed, thu, fri, sat, sun", strings.TrimSpace(p))
+				}
+				rule.DaysOfWeekNums = append(rule.DaysOfWeekNums, num)
+				rule.DaysOfWeek = append(rule.DaysOfWeek, weekdayName[num])
+			}
+		case reminder.FrequencyMonthly:
+			for _, p := range parts {
+				d, err := strconv.Atoi(strings.TrimSpace(p))
+				if err != nil || d < 1 || d > 31 {
+					return reminder.RecurrenceRule{}, fmt.Errorf("invalid day of month: %q — use 1-31", strings.TrimSpace(p))
+				}
+				rule.DaysOfMonth = append(rule.DaysOfMonth, d)
+			}
+		default:
+			return reminder.RecurrenceRule{}, fmt.Errorf("'on' clause not supported for %s frequency", base)
+		}
+	}
+
+	return rule, nil
 }
 
 // completeFilter builds the filter for the complete/uncomplete interactive flow.

--- a/cmd/rem/commands/filters_test.go
+++ b/cmd/rem/commands/filters_test.go
@@ -1,6 +1,10 @@
 package commands
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/BRO3886/rem/internal/reminder"
+)
 
 func TestCompleteFilter(t *testing.T) {
 	t.Run("complete shows incomplete reminders", func(t *testing.T) {
@@ -97,6 +101,124 @@ func TestFlagFilter(t *testing.T) {
 			t.Errorf("expected Flagged=nil, got %v", *f.Flagged)
 		}
 	})
+}
+
+func TestParseRecurrence(t *testing.T) {
+	tests := []struct {
+		input       string
+		wantErr     bool
+		frequency   reminder.RecurrenceFrequency
+		interval    int
+		daysOfWeek  []int
+		daysOfMonth []int
+		desc        string
+	}{
+		// Simple keywords
+		{"daily", false, reminder.FrequencyDaily, 1, nil, nil, "daily keyword"},
+		{"every day", false, reminder.FrequencyDaily, 1, nil, nil, "every day"},
+		{"weekly", false, reminder.FrequencyWeekly, 1, nil, nil, "weekly keyword"},
+		{"every week", false, reminder.FrequencyWeekly, 1, nil, nil, "every week"},
+		{"monthly", false, reminder.FrequencyMonthly, 1, nil, nil, "monthly keyword"},
+		{"every month", false, reminder.FrequencyMonthly, 1, nil, nil, "every month"},
+		{"yearly", false, reminder.FrequencyYearly, 1, nil, nil, "yearly keyword"},
+		{"every year", false, reminder.FrequencyYearly, 1, nil, nil, "every year"},
+
+		// Every N units
+		{"every 2 days", false, reminder.FrequencyDaily, 2, nil, nil, "every 2 days"},
+		{"every 3 weeks", false, reminder.FrequencyWeekly, 3, nil, nil, "every 3 weeks"},
+		{"every 2 months", false, reminder.FrequencyMonthly, 2, nil, nil, "every 2 months"},
+		{"every 5 years", false, reminder.FrequencyYearly, 5, nil, nil, "every 5 years"},
+		{"every 1 day", false, reminder.FrequencyDaily, 1, nil, nil, "every 1 day (singular)"},
+		{"every 1 week", false, reminder.FrequencyWeekly, 1, nil, nil, "every 1 week (singular)"},
+
+		// Weekly with days
+		{"weekly on mon", false, reminder.FrequencyWeekly, 1, []int{2}, nil, "weekly on monday"},
+		{"weekly on mon,wed,fri", false, reminder.FrequencyWeekly, 1, []int{2, 4, 6}, nil, "weekly on MWF"},
+		{"every 2 weeks on tue,thu", false, reminder.FrequencyWeekly, 2, []int{3, 5}, nil, "biweekly on tue/thu"},
+		{"weekly on sun", false, reminder.FrequencyWeekly, 1, []int{1}, nil, "weekly on sunday"},
+		{"weekly on sat", false, reminder.FrequencyWeekly, 1, []int{7}, nil, "weekly on saturday"},
+		{"weekly on monday,friday", false, reminder.FrequencyWeekly, 1, []int{2, 6}, nil, "weekly full day names"},
+
+		// Monthly with days of month
+		{"monthly on 1", false, reminder.FrequencyMonthly, 1, nil, []int{1}, "monthly on 1st"},
+		{"monthly on 1,15", false, reminder.FrequencyMonthly, 1, nil, []int{1, 15}, "monthly on 1st and 15th"},
+		{"every 2 months on 10", false, reminder.FrequencyMonthly, 2, nil, []int{10}, "bimonthly on 10th"},
+
+		// Case insensitivity
+		{"DAILY", false, reminder.FrequencyDaily, 1, nil, nil, "uppercase DAILY"},
+		{"Weekly On Mon,Fri", false, reminder.FrequencyWeekly, 1, []int{2, 6}, nil, "mixed case"},
+
+		// Whitespace handling
+		{"  daily  ", false, reminder.FrequencyDaily, 1, nil, nil, "extra whitespace"},
+
+		// Error cases
+		{"", true, 0, 0, nil, nil, "empty string"},
+		{"biweekly", true, 0, 0, nil, nil, "unknown keyword"},
+		{"every potato", true, 0, 0, nil, nil, "invalid unit"},
+		{"weekly on xyz", true, 0, 0, nil, nil, "invalid day name"},
+		{"monthly on 0", true, 0, 0, nil, nil, "day 0 invalid"},
+		{"monthly on 32", true, 0, 0, nil, nil, "day 32 invalid"},
+		{"monthly on abc", true, 0, 0, nil, nil, "non-numeric day of month"},
+		{"daily on mon", true, 0, 0, nil, nil, "on clause not supported for daily"},
+		{"yearly on mon", true, 0, 0, nil, nil, "on clause not supported for yearly"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			rule, err := parseRecurrence(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for input %q, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error for input %q: %v", tt.input, err)
+				return
+			}
+			if rule.Frequency != tt.frequency {
+				t.Errorf("frequency: got %d, want %d", rule.Frequency, tt.frequency)
+			}
+			if rule.Interval != tt.interval {
+				t.Errorf("interval: got %d, want %d", rule.Interval, tt.interval)
+			}
+			if len(rule.DaysOfWeekNums) != len(tt.daysOfWeek) {
+				t.Errorf("days of week: got %v, want %v", rule.DaysOfWeekNums, tt.daysOfWeek)
+			} else {
+				for i, d := range rule.DaysOfWeekNums {
+					if d != tt.daysOfWeek[i] {
+						t.Errorf("day of week[%d]: got %d, want %d", i, d, tt.daysOfWeek[i])
+					}
+				}
+			}
+			if len(rule.DaysOfMonth) != len(tt.daysOfMonth) {
+				t.Errorf("days of month: got %v, want %v", rule.DaysOfMonth, tt.daysOfMonth)
+			} else {
+				for i, d := range rule.DaysOfMonth {
+					if d != tt.daysOfMonth[i] {
+						t.Errorf("day of month[%d]: got %d, want %d", i, d, tt.daysOfMonth[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestParseRecurrenceDisplayNames(t *testing.T) {
+	// Verify DaysOfWeek display names are populated alongside DaysOfWeekNums
+	rule, err := parseRecurrence("weekly on mon,wed,fri")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expectedNames := []string{"Mon", "Wed", "Fri"}
+	if len(rule.DaysOfWeek) != len(expectedNames) {
+		t.Fatalf("DaysOfWeek: got %v, want %v", rule.DaysOfWeek, expectedNames)
+	}
+	for i, name := range rule.DaysOfWeek {
+		if name != expectedNames[i] {
+			t.Errorf("DaysOfWeek[%d]: got %q, want %q", i, name, expectedNames[i])
+		}
+	}
 }
 
 func TestUnflagFilter(t *testing.T) {

--- a/cmd/rem/commands/update.go
+++ b/cmd/rem/commands/update.go
@@ -17,6 +17,7 @@ var (
 	updateFlagged     string
 	updateList        string
 	updateRemindMe    string
+	updateRepeat      string
 	updateInteractive bool
 )
 
@@ -30,6 +31,8 @@ var updateCmd = &cobra.Command{
   rem edit abc12345 --name "New title"
   rem update abc12345 --list "Work"
   rem update abc12345 --remind-me 15m
+  rem update abc12345 --repeat "weekly on mon,fri"
+  rem update abc12345 --repeat none
   rem update -i
   rem update -i abc12345`,
 	Args: func(cmd *cobra.Command, args []string) error {
@@ -105,6 +108,17 @@ var updateCmd = &cobra.Command{
 				updates["alarms"] = []reminder.Alarm{alarm}
 			}
 		}
+		if cmd.Flags().Changed("repeat") {
+			if updateRepeat == "" || updateRepeat == "none" {
+				updates["recurrence"] = nil
+			} else {
+				rule, err := parseRecurrence(updateRepeat)
+				if err != nil {
+					return err
+				}
+				updates["recurrence"] = []reminder.RecurrenceRule{rule}
+			}
+		}
 
 		if len(updates) == 0 {
 			return fmt.Errorf("no updates specified")
@@ -129,6 +143,7 @@ func init() {
 	updateCmd.Flags().StringVar(&updateFlagged, "flagged", "", "Set flagged status: true/false")
 	updateCmd.Flags().StringVarP(&updateList, "list", "l", "", "Move reminder to a different list")
 	updateCmd.Flags().StringVar(&updateRemindMe, "remind-me", "", "Set alarm: duration before due (15m, 1h, 2d), 'none' to clear")
+	updateCmd.Flags().StringVar(&updateRepeat, "repeat", "", "Set recurrence: daily, weekly, 'weekly on mon,wed,fri', 'none' to clear")
 	updateCmd.Flags().BoolVarP(&updateInteractive, "interactive", "i", false, "Update interactively")
 
 	rootCmd.AddCommand(updateCmd)

--- a/internal/reminder/model.go
+++ b/internal/reminder/model.go
@@ -98,9 +98,11 @@ const (
 
 // RecurrenceRule defines how a reminder repeats.
 type RecurrenceRule struct {
-	Frequency  RecurrenceFrequency
-	Interval   int
-	DaysOfWeek []string // e.g., ["Mon", "Wed", "Fri"]
+	Frequency      RecurrenceFrequency
+	Interval       int
+	DaysOfWeek     []string // e.g., ["Mon", "Wed", "Fri"] — display names
+	DaysOfWeekNums []int    // eventkit weekday numbers (1=Sun..7=Sat) — for creation
+	DaysOfMonth    []int    // e.g., [1, 15] — for monthly rules
 }
 
 // FormatRecurrence returns a human-readable recurrence description.
@@ -134,6 +136,12 @@ func (r RecurrenceRule) String() string {
 	}
 	if len(r.DaysOfWeek) > 0 {
 		freq += " on " + strings.Join(r.DaysOfWeek, ", ")
+	} else if len(r.DaysOfMonth) > 0 {
+		days := make([]string, len(r.DaysOfMonth))
+		for i, d := range r.DaysOfMonth {
+			days[i] = fmt.Sprintf("%d", d)
+		}
+		freq += " on day " + strings.Join(days, ", ")
 	}
 	return freq
 }

--- a/internal/service/reminders.go
+++ b/internal/service/reminders.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	eventkit "github.com/BRO3886/go-eventkit"
 	"github.com/BRO3886/go-eventkit/reminders"
 	"github.com/BRO3886/rem/internal/reminder"
 )
@@ -52,6 +53,10 @@ func (s *ReminderService) CreateReminder(r *reminder.Reminder) (string, error) {
 			AbsoluteDate:   a.AbsoluteDate,
 			RelativeOffset: a.RelativeOffset,
 		})
+	}
+
+	for _, rr := range r.RecurrenceRules {
+		input.RecurrenceRules = append(input.RecurrenceRules, toEventKitRecurrenceRule(rr))
 	}
 
 	created, err := s.client.CreateReminder(input)
@@ -263,6 +268,18 @@ func (s *ReminderService) UpdateReminder(id string, updates map[string]any) erro
 				}
 				input.Alarms = &ekAlarms
 			}
+		case "recurrence":
+			if value == nil {
+				empty := []eventkit.RecurrenceRule{}
+				input.RecurrenceRules = &empty
+			} else {
+				rules := value.([]reminder.RecurrenceRule)
+				ekRules := make([]eventkit.RecurrenceRule, len(rules))
+				for i, rr := range rules {
+					ekRules[i] = toEventKitRecurrenceRule(rr)
+				}
+				input.RecurrenceRules = &ekRules
+			}
 		}
 	}
 
@@ -271,7 +288,7 @@ func (s *ReminderService) UpdateReminder(id string, updates map[string]any) erro
 		input.DueDate != nil || input.ClearDueDate ||
 		input.RemindMeDate != nil || input.Priority != nil ||
 		input.Completed != nil || input.URL != nil || input.ListName != nil ||
-		input.Alarms != nil
+		input.Alarms != nil || input.RecurrenceRules != nil
 
 	if hasEventKitUpdates {
 		if _, err := s.client.UpdateReminder(id, input); err != nil {
@@ -357,6 +374,26 @@ func (s *ReminderService) UnflagReminder(id string) error {
 	return s.updateViaAppleScript(id, map[string]any{"flagged": false})
 }
 
+// toEventKitRecurrenceRule converts a domain RecurrenceRule to an eventkit RecurrenceRule.
+func toEventKitRecurrenceRule(rr reminder.RecurrenceRule) eventkit.RecurrenceRule {
+	switch rr.Frequency {
+	case reminder.FrequencyDaily:
+		return eventkit.Daily(rr.Interval)
+	case reminder.FrequencyWeekly:
+		var days []eventkit.Weekday
+		for _, d := range rr.DaysOfWeekNums {
+			days = append(days, eventkit.Weekday(d))
+		}
+		return eventkit.Weekly(rr.Interval, days...)
+	case reminder.FrequencyMonthly:
+		return eventkit.Monthly(rr.Interval, rr.DaysOfMonth...)
+	case reminder.FrequencyYearly:
+		return eventkit.Yearly(rr.Interval)
+	default:
+		return eventkit.Daily(1)
+	}
+}
+
 // fromEventKitReminder converts a go-eventkit Reminder to an internal Reminder.
 func fromEventKitReminder(r *reminders.Reminder) *reminder.Reminder {
 	result := &reminder.Reminder{
@@ -380,11 +417,13 @@ func fromEventKitReminder(r *reminders.Reminder) *reminder.Reminder {
 	// Map recurrence rules
 	for _, rule := range r.RecurrenceRules {
 		rr := reminder.RecurrenceRule{
-			Frequency: reminder.RecurrenceFrequency(rule.Frequency),
-			Interval:  rule.Interval,
+			Frequency:   reminder.RecurrenceFrequency(rule.Frequency),
+			Interval:    rule.Interval,
+			DaysOfMonth: rule.DaysOfTheMonth,
 		}
 		for _, dow := range rule.DaysOfTheWeek {
 			rr.DaysOfWeek = append(rr.DaysOfWeek, dow.DayOfTheWeek.String())
+			rr.DaysOfWeekNums = append(rr.DaysOfWeekNums, int(dow.DayOfTheWeek))
 		}
 		result.RecurrenceRules = append(result.RecurrenceRules, rr)
 	}

--- a/skills/rem-cli/SKILL.md
+++ b/skills/rem-cli/SKILL.md
@@ -196,6 +196,6 @@ See [go-eventkit docs](https://github.com/BRO3886/go-eventkit) for the full API 
 
 - **macOS only** — requires EventKit framework and `osascript`
 - **No tags or subtasks** — not exposed by EventKit/AppleScript
-- **Recurrence is read-only** — displayed in `rem show` but cannot be created/modified via CLI
+- **Recurrence via `--repeat`** — supports daily, weekly (with day selection), monthly (with day-of-month selection), yearly. Use `--repeat none` to clear
 - **`--flagged` filter is slower** (~3-4s) — falls back to JXA since EventKit doesn't expose flagged
 - **List deletion** may fail on some macOS versions

--- a/skills/rem-cli/references/commands.md
+++ b/skills/rem-cli/references/commands.md
@@ -21,6 +21,7 @@ rem add -i   # Interactive mode
 | `--url` | `-u` | URL to attach (stored in body) | None |
 | `--flagged` | `-f` | Flag the reminder | false |
 | `--remind-me` | — | Set alarm: duration before due (15m, 1h, 2d) or absolute time | None |
+| `--repeat` | — | Set recurrence: daily, weekly, monthly, yearly, or 'weekly on mon,wed,fri' | None |
 | `--interactive` | `-i` | Create interactively | false |
 
 Aliases: `create`, `new`
@@ -98,6 +99,7 @@ rem update abc12345 -i            # Interactive mode
 | `--url` | `-u` | New URL | — |
 | `--flagged` | — | Set flagged: true/false | — |
 | `--remind-me` | — | Set alarm: duration (15m, 1h, 2d), 'none' to clear | — |
+| `--repeat` | — | Set recurrence: daily, weekly, monthly, yearly, 'none' to clear | — |
 | `--interactive` | `-i` | Update interactively | false |
 
 Aliases: `edit`

--- a/website/content/docs/commands.md
+++ b/website/content/docs/commands.md
@@ -47,6 +47,7 @@ rem add "Buy groceries" --due tomorrow --priority high --list Personal
 | `-u, --url` | URL to attach (stored in body) |
 | `-f, --flagged` | Flag the reminder |
 | `--remind-me` | Set alarm: duration before due (`15m`, `1h`, `2d`) or absolute time |
+| `--repeat` | Set recurrence: `daily`, `weekly`, `monthly`, `yearly`, or `weekly on mon,wed,fri` |
 | `-i, --interactive` | Step-by-step interactive creation |
 
 ### `rem list`
@@ -101,6 +102,7 @@ rem update 6ECE --priority medium --due "next friday"
 | `-u, --url` | New URL |
 | `--flagged` | Set flag: `true` or `false` |
 | `--remind-me` | Set alarm: duration (`15m`, `1h`, `2d`), `none` to clear |
+| `--repeat` | Set recurrence: `daily`, `weekly`, `monthly`, `yearly`, `none` to clear |
 | `-i, --interactive` | Interactive update |
 
 ### `rem complete`

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -28,10 +28,10 @@ sudo mv rem /usr/local/bin/rem
 
 ## Commands (all 20)
 
-rem add "title" [--due DATE] [--priority high|medium|low|none] [--list NAME] [--notes TEXT] [--url URL] [--flagged] [--remind-me DURATION] [-i]
+rem add "title" [--due DATE] [--priority high|medium|low|none] [--list NAME] [--notes TEXT] [--url URL] [--flagged] [--remind-me DURATION] [--repeat PATTERN] [-i]
 rem list [--list NAME] [--incomplete] [--completed] [--flagged] [--due-before DATE] [--due-after DATE] [-s QUERY]
 rem show ID
-rem update ID [--name TEXT] [--due DATE] [--priority LEVEL] [--notes TEXT] [--url URL] [--flagged true|false] [--remind-me DURATION] [--list NAME] [-i]
+rem update ID [--name TEXT] [--due DATE] [--priority LEVEL] [--notes TEXT] [--url URL] [--flagged true|false] [--remind-me DURATION] [--repeat PATTERN] [--list NAME] [-i]
 rem complete ID
 rem uncomplete ID
 rem flag ID


### PR DESCRIPTION
## Summary
- Add `--repeat` flag to `rem add` and `rem update` for recurrence creation/modification
- Support patterns: `daily`, `weekly`, `weekly on mon,wed,fri`, `every 2 weeks`, `monthly`, `monthly on 1,15`, `yearly`
- Support `--repeat none` on update to clear recurrence
- 36 unit tests for parseRecurrence covering all patterns and error cases
- Improve recurrence display: monthly rules now show "on day 1, 15"
- Update all docs: README, SKILL.md, skill refs, website, llms-full.txt

## Test plan
- [x] `go test ./...` — all pass (36 new parseRecurrence tests)
- [x] Smoke tested: daily, weekly, weekly on MWF, biweekly, monthly, monthly on 1/15, yearly
- [x] Smoke tested update --repeat and --repeat none (clear)
- [x] Verified recurrence display in `rem show` and table status column

Partial fix for #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)
