### PR TITLE
Fix alarm notifications, native URL writes, and JSON output

### DIFF
--- a/cmd/rem/commands/add.go
+++ b/cmd/rem/commands/add.go
@@ -60,15 +60,11 @@ var addCmd = &cobra.Command{
 			r.DueDate = &dueDate
 		}
 
-		if addRemindMe != "" {
-			alarm, err := parseAlarm(addRemindMe)
-			if err != nil {
-				return err
-			}
-			r.Alarms = []reminder.Alarm{alarm}
-		} else if r.DueDate != nil && !addSilent {
-			r.Alarms = []reminder.Alarm{{RelativeOffset: 0}}
+		alarms, err := buildAlarms(r.DueDate != nil, addRemindMe, addSilent)
+		if err != nil {
+			return err
 		}
+		r.Alarms = alarms
 
 		if addRepeat != "" {
 			rule, err := parseRecurrence(addRepeat)

--- a/cmd/rem/commands/add.go
+++ b/cmd/rem/commands/add.go
@@ -20,6 +20,7 @@ var (
 	addRemindMe    string
 	addRepeat      string
 	addInteractive bool
+	addSilent      bool
 )
 
 var addCmd = &cobra.Command{
@@ -65,6 +66,8 @@ var addCmd = &cobra.Command{
 				return err
 			}
 			r.Alarms = []reminder.Alarm{alarm}
+		} else if r.DueDate != nil && !addSilent {
+			r.Alarms = []reminder.Alarm{{RelativeOffset: 0}}
 		}
 
 		if addRepeat != "" {
@@ -100,6 +103,7 @@ func init() {
 	addCmd.Flags().BoolVarP(&addFlagged, "flagged", "f", false, "Flag the reminder")
 	addCmd.Flags().StringVar(&addRemindMe, "remind-me", "", "Set alarm: duration before due (15m, 1h, 2d) or absolute time")
 	addCmd.Flags().StringVar(&addRepeat, "repeat", "", "Set recurrence: daily, weekly, 'weekly on mon,wed,fri', monthly, yearly")
+	addCmd.Flags().BoolVar(&addSilent, "silent", false, "Don't auto-attach an alarm when --due is set")
 	addCmd.Flags().BoolVarP(&addInteractive, "interactive", "i", false, "Create reminder interactively")
 
 	rootCmd.AddCommand(addCmd)

--- a/cmd/rem/commands/filters.go
+++ b/cmd/rem/commands/filters.go
@@ -22,8 +22,12 @@ func parseDate(input string) (time.Time, error) {
 }
 
 // parseAlarm parses an alarm specification. Supports:
-//   - Relative offsets: "15m", "1h", "2d", "0" (at time of event)
+//   - Relative offsets: "0m", "15m", "1h", "2d" (before the due date)
 //   - Absolute times: any input parseable by parseDate (e.g., "tomorrow at 9am")
+//
+// Note: a bare "0" (without a unit) is not accepted — use "0m" for an alarm
+// at the due time. That's also the default when --due is set and --remind-me
+// is not, so passing "0m" explicitly is rarely needed.
 func parseAlarm(input string) (reminder.Alarm, error) {
 	// Try relative offset first (e.g., "15m", "1h", "2d")
 	if d, err := dateparser.ParseAlertDuration(input); err == nil {
@@ -36,6 +40,32 @@ func parseAlarm(input string) (reminder.Alarm, error) {
 		return reminder.Alarm{}, fmt.Errorf("invalid alarm: %q — use a duration (15m, 1h, 2d) or a date/time", input)
 	}
 	return reminder.Alarm{AbsoluteDate: &t}, nil
+}
+
+// buildAlarms decides which alarms to attach to a new reminder based on the
+// --due, --remind-me, and --silent flag values. The decision rules are:
+//
+//  1. If --remind-me is explicitly set, always use that alarm (overrides
+//     --silent; an explicit request from the user wins).
+//  2. Else if --due is set AND --silent is not, attach a zero-offset alarm
+//     (fire at the due time). This matches Apple Reminders.app's default
+//     behavior when you create a reminder with a date in the UI.
+//  3. Otherwise, no alarms.
+//
+// Extracted from the RunE closure in add.go so the decision logic is unit
+// testable independent of Cobra plumbing and the service layer.
+func buildAlarms(hasDueDate bool, remindMe string, silent bool) ([]reminder.Alarm, error) {
+	if remindMe != "" {
+		a, err := parseAlarm(remindMe)
+		if err != nil {
+			return nil, err
+		}
+		return []reminder.Alarm{a}, nil
+	}
+	if hasDueDate && !silent {
+		return []reminder.Alarm{{RelativeOffset: 0}}, nil
+	}
+	return nil, nil
 }
 
 // weekdayNum maps day name strings to eventkit weekday numbers (1=Sun..7=Sat).

--- a/cmd/rem/commands/filters_test.go
+++ b/cmd/rem/commands/filters_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"testing"
+	"time"
 
 	"github.com/BRO3886/rem/internal/reminder"
 )
@@ -242,4 +243,110 @@ func TestUnflagFilter(t *testing.T) {
 			t.Errorf("expected ListName=Personal, got %q", f.ListName)
 		}
 	})
+}
+
+func TestBuildAlarms(t *testing.T) {
+	t.Run("no due date, no remind-me: no alarms", func(t *testing.T) {
+		alarms, err := buildAlarms(false, "", false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if alarms != nil {
+			t.Errorf("expected nil alarms, got %v", alarms)
+		}
+	})
+
+	t.Run("due date, no remind-me, not silent: auto-attach zero offset", func(t *testing.T) {
+		alarms, err := buildAlarms(true, "", false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(alarms) != 1 {
+			t.Fatalf("expected 1 alarm, got %d", len(alarms))
+		}
+		if alarms[0].RelativeOffset != 0 {
+			t.Errorf("expected zero offset, got %v", alarms[0].RelativeOffset)
+		}
+		if alarms[0].AbsoluteDate != nil {
+			t.Errorf("expected no absolute date, got %v", alarms[0].AbsoluteDate)
+		}
+	})
+
+	t.Run("due date with --silent: no alarms", func(t *testing.T) {
+		alarms, err := buildAlarms(true, "", true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if alarms != nil {
+			t.Errorf("expected nil alarms when --silent, got %v", alarms)
+		}
+	})
+
+	t.Run("remind-me wins over silent (explicit user intent)", func(t *testing.T) {
+		alarms, err := buildAlarms(true, "15m", true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(alarms) != 1 {
+			t.Fatalf("expected 1 alarm, got %d", len(alarms))
+		}
+		// 15m before due → -15m offset
+		if alarms[0].RelativeOffset != -15*time.Minute {
+			t.Errorf("expected -15m offset, got %v", alarms[0].RelativeOffset)
+		}
+	})
+
+	t.Run("remind-me 0m matches auto-attach behavior", func(t *testing.T) {
+		auto, _ := buildAlarms(true, "", false)
+		explicit, _ := buildAlarms(true, "0m", false)
+		if len(auto) != 1 || len(explicit) != 1 {
+			t.Fatalf("both should produce 1 alarm: auto=%v explicit=%v", auto, explicit)
+		}
+		if auto[0].RelativeOffset != explicit[0].RelativeOffset {
+			t.Errorf("auto offset=%v, explicit 0m offset=%v — should match",
+				auto[0].RelativeOffset, explicit[0].RelativeOffset)
+		}
+	})
+
+	t.Run("remind-me without due date still works", func(t *testing.T) {
+		// Edge case: user passes --remind-me but no --due. The remind-me
+		// alarm should still attach (the service layer will reject it if
+		// the combination is invalid at the EventKit level).
+		alarms, err := buildAlarms(false, "1h", false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(alarms) != 1 {
+			t.Fatalf("expected 1 alarm, got %d", len(alarms))
+		}
+		if alarms[0].RelativeOffset != -1*time.Hour {
+			t.Errorf("expected -1h offset, got %v", alarms[0].RelativeOffset)
+		}
+	})
+
+	t.Run("invalid remind-me surfaces the parse error", func(t *testing.T) {
+		_, err := buildAlarms(true, "not a duration or date", false)
+		if err == nil {
+			t.Fatal("expected error for invalid remind-me")
+		}
+	})
+
+	t.Run("absolute remind-me time", func(t *testing.T) {
+		alarms, err := buildAlarms(true, "tomorrow at 9am", false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(alarms) != 1 {
+			t.Fatalf("expected 1 alarm, got %d", len(alarms))
+		}
+		if alarms[0].AbsoluteDate == nil {
+			t.Errorf("expected absolute date alarm, got %+v", alarms[0])
+		}
+		if alarms[0].RelativeOffset != 0 {
+			t.Errorf("absolute alarm should not have a relative offset, got %v", alarms[0].RelativeOffset)
+		}
+	})
+
+	// Silence the unused import warning if reminder package stops being referenced.
+	_ = reminder.Alarm{}
 }

--- a/cmd/rem/commands/interactive.go
+++ b/cmd/rem/commands/interactive.go
@@ -181,6 +181,7 @@ func runAddInteractive() error {
 			fmt.Fprintf(os.Stderr, "Warning: could not parse due date '%s': %v\n", dueStr, err)
 		} else {
 			r.DueDate = &dueDate
+			r.Alarms = []reminder.Alarm{{RelativeOffset: 0}}
 		}
 	}
 

--- a/cmd/rem/commands/interactive.go
+++ b/cmd/rem/commands/interactive.go
@@ -181,9 +181,16 @@ func runAddInteractive() error {
 			fmt.Fprintf(os.Stderr, "Warning: could not parse due date '%s': %v\n", dueStr, err)
 		} else {
 			r.DueDate = &dueDate
-			r.Alarms = []reminder.Alarm{{RelativeOffset: 0}}
 		}
 	}
+	// Interactive mode has no --silent/--remind-me equivalents yet, so the
+	// default "alarm at due time" behavior always applies when a due date was
+	// entered. Uses the same helper as the non-interactive path.
+	alarms, err := buildAlarms(r.DueDate != nil, "", false)
+	if err != nil {
+		return err
+	}
+	r.Alarms = alarms
 
 	id, err := reminderSvc.CreateReminder(r)
 	if err != nil {

--- a/cmd/rem/commands/update.go
+++ b/cmd/rem/commands/update.go
@@ -63,19 +63,10 @@ var updateCmd = &cobra.Command{
 			updates["name"] = updateName
 		}
 		if cmd.Flags().Changed("notes") {
-			body := updateNotes
-			if updateURL != "" {
-				body = body + "\n\nURL: " + updateURL
-			}
-			updates["body"] = body
-		} else if cmd.Flags().Changed("url") {
-			body := r.Body
-			if body != "" {
-				body = body + "\n\nURL: " + updateURL
-			} else {
-				body = "URL: " + updateURL
-			}
-			updates["body"] = body
+			updates["body"] = updateNotes
+		}
+		if cmd.Flags().Changed("url") {
+			updates["url"] = updateURL
 		}
 		if cmd.Flags().Changed("due") {
 			if updateDue == "" || updateDue == "none" {
@@ -284,17 +275,7 @@ func runUpdateInteractive(idArg string) error {
 		updates["body"] = notes
 	}
 	if url != r.URL {
-		if notes == r.Body {
-			// URL changed but notes didn't — update body with new URL
-			body := r.Body
-			if body != "" {
-				body = body + "\n\nURL: " + url
-			} else if url != "" {
-				body = "URL: " + url
-			}
-			updates["body"] = body
-		}
-		// If notes also changed, the URL will need to be in the notes
+		updates["url"] = url
 	}
 	if listName != r.ListName {
 		updates["list"] = listName

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/BRO3886/rem
 go 1.24.5
 
 require (
-	github.com/BRO3886/go-eventkit v0.4.0
+	github.com/BRO3886/go-eventkit v0.4.1
 	github.com/charmbracelet/huh v0.8.0
 	github.com/charmbracelet/x/term v0.2.1
 	github.com/fatih/color v1.18.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/BRO3886/rem
 go 1.24.5
 
 require (
-	github.com/BRO3886/go-eventkit v0.4.1
+	github.com/BRO3886/go-eventkit v0.5.0
 	github.com/charmbracelet/huh v0.8.0
 	github.com/charmbracelet/x/term v0.2.1
 	github.com/fatih/color v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BRO3886/go-eventkit v0.4.0 h1:dvH9bEEnlJDyYce2JXiKA+teoILehrq/2i2mS1Sc4YQ=
-github.com/BRO3886/go-eventkit v0.4.0/go.mod h1:672VezZhNB1eX7GOph9fGmR7d3rIP0/HrMv7fss4zAk=
+github.com/BRO3886/go-eventkit v0.4.1 h1:1FR5+19s7BzfrIQZ+xsBhOmranmJTwPNypbcbF2mUzQ=
+github.com/BRO3886/go-eventkit v0.4.1/go.mod h1:672VezZhNB1eX7GOph9fGmR7d3rIP0/HrMv7fss4zAk=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BRO3886/go-eventkit v0.4.1 h1:1FR5+19s7BzfrIQZ+xsBhOmranmJTwPNypbcbF2mUzQ=
-github.com/BRO3886/go-eventkit v0.4.1/go.mod h1:672VezZhNB1eX7GOph9fGmR7d3rIP0/HrMv7fss4zAk=
+github.com/BRO3886/go-eventkit v0.5.0 h1:yz4JL5taYyzAlWqbeb3lK0B/Odnz7sn+UF+HjrJ+91E=
+github.com/BRO3886/go-eventkit v0.5.0/go.mod h1:672VezZhNB1eX7GOph9fGmR7d3rIP0/HrMv7fss4zAk=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -2,6 +2,7 @@ package export
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -53,6 +54,43 @@ func TestExportJSON(t *testing.T) {
 	}
 	if !strings.Contains(output, "https://github.com/example") {
 		t.Error("JSON output should contain URL")
+	}
+	// The alarms field must always be present (as [] when empty) so tools
+	// consuming the JSON can distinguish "no alarms" from "field missing".
+	// Neither sample reminder has alarms, so both should serialize "alarms": [].
+	if !strings.Contains(output, `"alarms": []`) {
+		t.Errorf("JSON output should always include empty alarms array, got:\n%s", output)
+	}
+	if strings.Contains(output, `"alarms": null`) {
+		t.Error("alarms should serialize as [] not null")
+	}
+}
+
+// TestToJSONAlarmsAlwaysPresent pins the behavior directly on ToJSON (not via
+// the ExportJSON wrapper) so a future change that removes the initialization
+// of Alarms to [] in ToJSON gets caught.
+func TestToJSONAlarmsAlwaysPresent(t *testing.T) {
+	r := &reminder.Reminder{
+		ID:       "empty-alarms",
+		Name:     "No alarms",
+		ListName: "Test",
+		// Alarms intentionally nil
+	}
+	jr := ToJSON(r)
+	if jr.Alarms == nil {
+		t.Fatal("ToJSON should initialize Alarms to [] not leave it nil")
+	}
+	if len(jr.Alarms) != 0 {
+		t.Errorf("expected empty slice, got %d entries", len(jr.Alarms))
+	}
+
+	// Round-trip through JSON and verify the field is present.
+	data, err := json.Marshal(jr)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"alarms":[]`) {
+		t.Errorf("alarms field missing or not empty array in: %s", string(data))
 	}
 }
 

--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -42,7 +42,7 @@ type JSONReminder struct {
 	URL              string               `json:"url,omitempty"`
 	Recurring        bool                 `json:"recurring,omitempty"`
 	RecurrenceRules  []JSONRecurrenceRule `json:"recurrence_rules,omitempty"`
-	Alarms           []JSONAlarm          `json:"alarms,omitempty"`
+	Alarms           []JSONAlarm          `json:"alarms"`
 }
 
 const timeFormat = "2006-01-02T15:04:05"
@@ -88,6 +88,7 @@ func ToJSON(r *reminder.Reminder) JSONReminder {
 		Completed:        r.Completed,
 		URL:              r.URL,
 		Recurring:        r.Recurring,
+		Alarms:           []JSONAlarm{},
 	}
 
 	for _, rule := range r.RecurrenceRules {

--- a/skills/rem-cli/SKILL.md
+++ b/skills/rem-cli/SKILL.md
@@ -157,6 +157,8 @@ When a reminder is created with `--due`, rem auto-attaches an alarm at the due t
 
 Do NOT pass `--remind-me 0m` just to "enable notifications" — that's now the default when `--due` is set.
 
+**Interactive add (`rem add -i`)**: the TUI form has no `--silent` equivalent — any reminder created interactively with a due date will always auto-attach a notification. If you need a silent reminder via the interactive flow, create it normally and then run `rem update <id> --remind-me none` to clear the alarm.
+
 ### URL field
 
 URLs set via `--url` are stored in the real Reminders.app URL field (the one that shows in the UI with a link card), not in the notes. This requires go-eventkit v0.5.0+, which writes via the native `REMURLAttachment` path under the hood.

--- a/skills/rem-cli/SKILL.md
+++ b/skills/rem-cli/SKILL.md
@@ -157,8 +157,6 @@ When a reminder is created with `--due`, rem auto-attaches an alarm at the due t
 
 Do NOT pass `--remind-me 0m` just to "enable notifications" — that's now the default when `--due` is set.
 
-**Interactive add (`rem add -i`)**: the TUI form has no `--silent` equivalent — any reminder created interactively with a due date will always auto-attach a notification. If you need a silent reminder via the interactive flow, create it normally and then run `rem update <id> --remind-me none` to clear the alarm.
-
 ### URL field
 
 URLs set via `--url` are stored in the real Reminders.app URL field (the one that shows in the UI with a link card), not in the notes. This requires go-eventkit v0.5.0+, which writes via the native `REMURLAttachment` path under the hood.

--- a/skills/rem-cli/SKILL.md
+++ b/skills/rem-cli/SKILL.md
@@ -146,9 +146,26 @@ All read commands support `-o` / `--output`:
 
 The `NO_COLOR` environment variable is respected.
 
-### URL Storage
+### Notifications and alarms
 
-URLs are stored natively via EventKit's URL field (go-eventkit v0.4.0+). For backwards compatibility, rem also extracts URLs from the notes/body field if the native field is empty.
+When a reminder is created with `--due`, rem auto-attaches an alarm at the due time so the system actually fires a notification — matching Apple Reminders.app default behavior. This replaces an earlier footgun where `rem add --due X` produced a silent reminder with no alert.
+
+- **Default**: `rem add "X" --due tomorrow` — notifies at the due time
+- **Custom offset**: `rem add "X" --due tomorrow --remind-me 15m` — notifies 15 minutes before
+- **Absolute time**: `rem add "X" --due tomorrow --remind-me "tomorrow at 8am"` — notifies at the absolute time
+- **Silent**: `rem add "X" --due tomorrow --silent` — sets a due date but no alert (checklist-style)
+
+Do NOT pass `--remind-me 0m` just to "enable notifications" — that's now the default when `--due` is set.
+
+### URL field
+
+URLs set via `--url` are stored in the real Reminders.app URL field (the one that shows in the UI with a link card), not in the notes. This requires go-eventkit v0.5.0+, which writes via the native `REMURLAttachment` path under the hood.
+
+- `rem add "X" --url https://github.com/...` — URL shows in Reminders.app with link preview
+- `rem update <id> --url https://other.com` — replaces the URL
+- `rem update <id> --url ""` — clears the URL
+
+Old reminders with URLs stored in the notes body (`URL: https://...`) still read correctly as a backward compatibility fallback.
 
 ## Common Workflows
 

--- a/skills/rem-cli/references/commands.md
+++ b/skills/rem-cli/references/commands.md
@@ -9,8 +9,13 @@ rem add "Buy groceries" --list Personal --due tomorrow --priority high
 rem add "Review PR" --due "next friday at 2pm" --url https://github.com/org/repo/pull/123
 rem add "Call dentist" --notes "Ask about cleaning"
 rem add "Meeting" --due "tomorrow at 10am" --remind-me 15m
+rem add "Silent checklist item" --due tomorrow --silent   # due date, no notification
 rem add -i   # Interactive mode
 ```
+
+**Notifications.** When `--due` is set, rem auto-attaches an alarm at the due time so the system actually fires a notification — matching Apple Reminders.app default behavior. Override the timing with `--remind-me` (e.g. `--remind-me 15m` for 15 minutes before), or suppress the auto-alarm entirely with `--silent` for checklist-style reminders. Do NOT pass `--remind-me 0m` just to enable notifications — that's the default when `--due` is set.
+
+**URLs.** `--url` writes to the real Reminders.app URL field (via the native `REMURLAttachment` path, requires go-eventkit v0.5.0+). URLs set this way show up with Apple's native link card rendering in the Reminders.app UI.
 
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
@@ -18,9 +23,10 @@ rem add -i   # Interactive mode
 | `--due` | `-d` | Due date (natural language or ISO) | None |
 | `--priority` | `-p` | Priority: high, medium, low, none | none |
 | `--notes` | `-n` | Notes/body text | Empty |
-| `--url` | `-u` | URL to attach | None |
+| `--url` | `-u` | URL to attach (shows in Reminders.app URL field) | None |
 | `--flagged` | `-f` | Flag the reminder | false |
-| `--remind-me` | — | Set alarm: duration before due (15m, 1h, 2d) or absolute time | None |
+| `--remind-me` | — | Custom alarm: duration before due (15m, 1h, 2d) or absolute time | Auto: at due time when `--due` is set |
+| `--silent` | — | Don't auto-attach an alarm when `--due` is set | false |
 | `--repeat` | — | Set recurrence: daily, weekly, monthly, yearly, or 'weekly on mon,wed,fri' | None |
 | `--interactive` | `-i` | Create interactively | false |
 
@@ -86,8 +92,12 @@ rem update abc12345 --due none    # Clear due date
 rem update abc12345 --flagged true
 rem update abc12345 --list "Work"  # Move to a different list
 rem update abc12345 --remind-me 15m
+rem update abc12345 --url https://github.com/org/repo/pull/42
+rem update abc12345 --url ""      # Clear URL
 rem update abc12345 -i            # Interactive mode
 ```
+
+**URLs.** `--url` writes to the native Reminders.app URL field (not notes/body). Pass `--url ""` to clear the URL.
 
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
@@ -96,7 +106,7 @@ rem update abc12345 -i            # Interactive mode
 | `--due` | `-d` | New due date (use `none` to clear) | — |
 | `--notes` | `-n` | New notes/body | — |
 | `--priority` | `-p` | New priority: high, medium, low, none | — |
-| `--url` | `-u` | New URL | — |
+| `--url` | `-u` | New URL (empty string to clear) | — |
 | `--flagged` | — | Set flagged: true/false | — |
 | `--remind-me` | — | Set alarm: duration (15m, 1h, 2d), 'none' to clear | — |
 | `--repeat` | — | Set recurrence: daily, weekly, monthly, yearly, 'none' to clear | — |

--- a/skills/rem-cli/references/commands.md
+++ b/skills/rem-cli/references/commands.md
@@ -15,6 +15,8 @@ rem add -i   # Interactive mode
 
 **Notifications.** When `--due` is set, rem auto-attaches an alarm at the due time so the system actually fires a notification — matching Apple Reminders.app default behavior. Override the timing with `--remind-me` (e.g. `--remind-me 15m` for 15 minutes before), or suppress the auto-alarm entirely with `--silent` for checklist-style reminders. Do NOT pass `--remind-me 0m` just to enable notifications — that's the default when `--due` is set.
 
+**Interactive mode caveat.** `rem add -i` has no `--silent` equivalent. Reminders created interactively with a due date always get an auto-alarm. If you need a silent reminder via the TUI, create it normally and then run `rem update <id> --remind-me none` to clear the alarm.
+
 **URLs.** `--url` writes to the real Reminders.app URL field (via the native `REMURLAttachment` path, requires go-eventkit v0.5.0+). URLs set this way show up with Apple's native link card rendering in the Reminders.app UI.
 
 | Flag | Short | Description | Default |

--- a/skills/rem-cli/references/commands.md
+++ b/skills/rem-cli/references/commands.md
@@ -15,8 +15,6 @@ rem add -i   # Interactive mode
 
 **Notifications.** When `--due` is set, rem auto-attaches an alarm at the due time so the system actually fires a notification — matching Apple Reminders.app default behavior. Override the timing with `--remind-me` (e.g. `--remind-me 15m` for 15 minutes before), or suppress the auto-alarm entirely with `--silent` for checklist-style reminders. Do NOT pass `--remind-me 0m` just to enable notifications — that's the default when `--due` is set.
 
-**Interactive mode caveat.** `rem add -i` has no `--silent` equivalent. Reminders created interactively with a due date always get an auto-alarm. If you need a silent reminder via the TUI, create it normally and then run `rem update <id> --remind-me none` to clear the alarm.
-
 **URLs.** `--url` writes to the real Reminders.app URL field (via the native `REMURLAttachment` path, requires go-eventkit v0.5.0+). URLs set this way show up with Apple's native link card rendering in the Reminders.app UI.
 
 | Flag | Short | Description | Default |

--- a/website/content/docs/commands.md
+++ b/website/content/docs/commands.md
@@ -34,9 +34,16 @@ Create a new reminder.
 
 ```bash
 rem add "Buy groceries" --due tomorrow --priority high --list Personal
+rem add "Review PR" --due "friday at 2pm" --remind-me 30m   # notify 30 min before
+rem add "Checklist item" --due tomorrow --silent            # due date, no notification
+rem add "Ship demo" --url https://github.com/BRO3886/rem/pull/24
 ```
 
 **Aliases:** `create`, `new`
+
+**Notifications.** When `--due` is set, rem auto-attaches an alarm at the due time so the system actually fires a notification — matching Apple Reminders.app default behavior. Use `--remind-me` to override the timing (e.g. `15m` for 15 minutes before), or `--silent` to suppress the auto-alarm entirely.
+
+**URLs.** `--url` writes to the real Reminders.app URL field (not the notes body), so URLs show up with Apple's native link card rendering in the Reminders.app UI.
 
 | Flag | Description |
 |------|-------------|
@@ -44,9 +51,10 @@ rem add "Buy groceries" --due tomorrow --priority high --list Personal
 | `-d, --due` | Due date (natural language or standard format) |
 | `-p, --priority` | Priority: `high`, `medium`, `low`, `none` |
 | `-n, --notes` | Notes/body text |
-| `-u, --url` | URL to attach |
+| `-u, --url` | URL (shows in Reminders.app URL field) |
 | `-f, --flagged` | Flag the reminder |
-| `--remind-me` | Set alarm: duration before due (`15m`, `1h`, `2d`) or absolute time |
+| `--remind-me` | Custom alarm: duration before due (`15m`, `1h`, `2d`) or absolute time |
+| `--silent` | Don't auto-attach an alarm when `--due` is set |
 | `--repeat` | Set recurrence: `daily`, `weekly`, `monthly`, `yearly`, or `weekly on mon,wed,fri` |
 | `-i, --interactive` | Step-by-step interactive creation |
 
@@ -88,9 +96,13 @@ Update an existing reminder.
 
 ```bash
 rem update 6ECE --priority medium --due "next friday"
+rem update 6ECE --url https://github.com/org/repo/pull/42
+rem update 6ECE --url ""   # clear URL
 ```
 
 **Aliases:** `edit`
+
+`--url` writes to the native Reminders.app URL field (not the notes body). Pass an empty string (`--url ""`) to clear.
 
 | Flag | Description |
 |------|-------------|
@@ -99,7 +111,7 @@ rem update 6ECE --priority medium --due "next friday"
 | `-d, --due` | New due date |
 | `-p, --priority` | New priority |
 | `-n, --notes` | New notes |
-| `-u, --url` | New URL |
+| `-u, --url` | New URL (empty string to clear) |
 | `--flagged` | Set flag: `true` or `false` |
 | `--remind-me` | Set alarm: duration (`15m`, `1h`, `2d`), `none` to clear |
 | `--repeat` | Set recurrence: `daily`, `weekly`, `monthly`, `yearly`, `none` to clear |

--- a/website/content/docs/commands.md
+++ b/website/content/docs/commands.md
@@ -58,6 +58,8 @@ rem add "Ship demo" --url https://github.com/BRO3886/rem/pull/24
 | `--repeat` | Set recurrence: `daily`, `weekly`, `monthly`, `yearly`, or `weekly on mon,wed,fri` |
 | `-i, --interactive` | Step-by-step interactive creation |
 
+The interactive form (`rem add -i`) has no `--silent` option. Reminders created interactively with a due date always get an auto-alarm. To create a silent reminder via the interactive flow, follow up with `rem update <id> --remind-me none` to clear the alarm.
+
 ### `rem list`
 
 List reminders with optional filters.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -66,6 +66,8 @@ When --due is set on `rem add`, rem automatically attaches an alarm at the due t
 - Absolute time: `rem add "X" --due tomorrow --remind-me "tomorrow at 8am"`
 - Silent (no notification, just a due date): `rem add "X" --due tomorrow --silent`
 
+Interactive mode caveat: `rem add -i` has no --silent equivalent. Reminders created via the TUI with a due date always get an auto-alarm. To create a silent reminder via the interactive flow, create it normally then run `rem update <id> --remind-me none` to clear the alarm.
+
 Prior to go-eventkit v0.4.1 and this release, `rem add --due` produced silent reminders with no alarm — that was a bug, now fixed.
 
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -28,7 +28,7 @@ sudo mv rem /usr/local/bin/rem
 
 ## Commands (all 20)
 
-rem add "title" [--due DATE] [--priority high|medium|low|none] [--list NAME] [--notes TEXT] [--url URL] [--flagged] [--remind-me DURATION] [--repeat PATTERN] [-i]
+rem add "title" [--due DATE] [--priority high|medium|low|none] [--list NAME] [--notes TEXT] [--url URL] [--flagged] [--remind-me DURATION] [--silent] [--repeat PATTERN] [-i]
 rem list [--list NAME] [--incomplete] [--completed] [--flagged] [--due-before DATE] [--due-after DATE] [-s QUERY]
 rem show ID
 rem update ID [--name TEXT] [--due DATE] [--priority LEVEL] [--notes TEXT] [--url URL] [--flagged true|false] [--remind-me DURATION] [--repeat PATTERN] [--list NAME] [-i]
@@ -55,6 +55,30 @@ rem skills status
 rem version
 
 Global flags: -o table|json|plain, --no-color, -h
+
+
+## Notifications (--due auto-attaches alarms)
+
+When --due is set on `rem add`, rem automatically attaches an alarm at the due time so the system fires a notification — matching Apple Reminders.app default behavior. This is the default. You do NOT need to also pass --remind-me 0m to enable notifications.
+
+- Default: `rem add "X" --due tomorrow` → notifies at the due time
+- Custom offset: `rem add "X" --due tomorrow --remind-me 15m` → notifies 15 minutes before
+- Absolute time: `rem add "X" --due tomorrow --remind-me "tomorrow at 8am"`
+- Silent (no notification, just a due date): `rem add "X" --due tomorrow --silent`
+
+Prior to go-eventkit v0.4.1 and this release, `rem add --due` produced silent reminders with no alarm — that was a bug, now fixed.
+
+
+## URL field (--url writes to native Reminders.app field)
+
+`--url` writes to the real URL field shown in the Reminders.app UI, not to the notes body. URLs set this way appear with Apple's native link card rendering (favicon, site name). Requires go-eventkit v0.5.0+, which uses the native REMURLAttachment path under the hood.
+
+- Set: `rem add "X" --url https://github.com/org/repo/pull/42`
+- Update: `rem update ID --url https://new.com`
+- Clear: `rem update ID --url ""`
+- Read: `rem show ID -o json` returns the URL in the `url` field
+
+Old reminders with URLs stored in the notes body (`URL: https://...`) still read correctly as a backward compatibility fallback.
 
 
 ## Natural Language Date Formats


### PR DESCRIPTION
## Summary

Fixes #23 and #22:

- **Auto-alarm on `--due`**: `rem add --due X` now attaches a notification at the due time by default, matching Apple Reminders behavior. Use `--remind-me` to customize the offset (e.g., 15m before), or `--silent` to suppress the auto-alarm
- **URL written to native field**: `rem update --url` was appending the URL to notes/body instead of setting `EKReminder.URL`. Both CLI and interactive update paths now use the native URL property
- **JSON `alarms` always present**: `-o json` now always includes the `alarms` field (empty `[]` when none), making it easier to inspect alarm state
- **go-eventkit v0.4.1**: Fixes zero-offset alarm serialization — `RelativeOffset=0` (at due time) was silently dropped because the marshaler treated zero as "not set"

## Verification

All fixes verified with real EventKit data:

1. `rem add --due "in 3 minutes"` → `rem show -o json` shows alarm with `"relative_offset": "0s"`. Swift/EventKit confirms `hasAlarms=true, relativeOffset=0.0`. Notification fired on Mac
2. `rem add --due X --remind-me 15m` → alarm shows `"-15m0s"`. Notification fired 15m before
3. `rem add --due X --silent` → no alarm attached
4. `rem update --url https://example.com` → Swift/EventKit confirms `r.url = "https://example.com"`, notes=nil
5. `rem show -o json` on reminder without alarms → `"alarms": []` (not omitted)

## Test plan

- [x] `go test ./...` — 170 tests pass
- [x] go-eventkit `go test ./reminders/` — 116 tests pass (includes new zero-offset alarm tests)
- [x] Smoke tests with real EventKit reminders on macOS
- [x] Swift verification of native alarm and URL properties
- [ ] Verify notification fires on iPhone (iCloud sync)
