### PR TITLE
Restore spec-valid frontmatter fields dropped in PR #30

### DIFF
--- a/skills/rem-cli/SKILL.md
+++ b/skills/rem-cli/SKILL.md
@@ -1,8 +1,13 @@
 ---
-name: rem
+name: rem-cli
 description: Create, list, update, complete, and search macOS Reminders via the rem CLI. Use when the user wants to manage Apple Reminders from the terminal, automate reminder workflows, reference reminders in shell scripts, or schedule anything on macOS.
+license: MIT
+compatibility: Requires macOS with the rem CLI installed (https://rem.sidv.dev)
 allowed-tools: Bash(rem *)
 argument-hint: "[natural language request]"
+metadata:
+  author: BRO3886
+  homepage: https://github.com/BRO3886/rem
 ---
 
 # rem — macOS Reminders from the terminal


### PR DESCRIPTION
## Summary

Restores `metadata`, `compatibility`, and `license` frontmatter fields that PR #30 incorrectly dropped, and fixes a spec-compliance bug where `name: rem` didn't match the parent directory `rem-cli/`.

## Why this is a bug

The [Agent Skills specification](https://agentskills.io/specification) explicitly lists these as valid optional frontmatter fields:

- **`license`** — "License name or reference to a bundled license file"
- **`compatibility`** — "Max 500 characters. Indicates environment requirements (intended product, system packages, network access, etc.)"
- **`metadata`** — "Arbitrary key-value mapping for additional metadata"

PR #30 dropped these assuming they weren't in the spec, based on reading only the [Claude Code skills docs](https://code.claude.com/docs/en/skills). Those docs enumerate Claude Code's extensions (`disable-model-invocation`, `context`, `agent`, etc.) but don't re-list the base Agent Skills fields. My mistake — I should have cross-checked against agentskills.io directly.

## What this adds back

```yaml
name: rem-cli                         # was `rem` — spec requires matching parent dir
description: Create, list, update, complete, and search macOS Reminders...
license: MIT                          # NEW — matches project license
compatibility: Requires macOS with the rem CLI installed (https://rem.sidv.dev)
allowed-tools: Bash(rem *)
argument-hint: "[natural language request]"
metadata:                             # NEW — spec-valid free-form map
  author: BRO3886
  homepage: https://github.com/BRO3886/rem
```

## Intentionally NOT restored

- **`metadata.version`** — the binary already encodes the version via `git describe -tags` at build time, and the installer tracks it via `.rem-version` for the installed-version check. Hard-coding a version in SKILL.md creates two sources of truth that drift. Every release would require editing this file. Leaving it out.

## Spec compliance fix

The spec says:

> Must match the parent directory name

The skill lives at `skills/rem-cli/` but frontmatter had `name: rem`, which is technically invalid. Claude Code and the rem installer both accepted it anyway (lenient parsers), but a stricter spec-compliance validator (like [skills-ref](https://github.com/agentskills/agentskills/tree/main/skills-ref)) would have flagged it. Changed to `name: rem-cli`.

## Test plan

- [x] `make build` — clean
- [x] `go test ./...` — 180 tests pass
- [x] Verified fields against https://agentskills.io/specification
- [x] Opus review — not repeated for a 6-line fix

## Release ordering

Shipping this as a quick PR before re-tagging v0.11.0 so the release tarball includes the spec-compliant skill. The v0.11.0 tag was deleted from origin (no release was created yet, so no users have pulled it) and will be re-created against the merge commit.
