### PR TITLE
Add Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A blazing fast CLI for macOS Reminders. Sub-200ms reads AND writes via EventKit,
 
 ```bash
 brew tap BRO3886/tap
-brew install rem
+brew install rem-cli
 ```
 
 ### Quick install (recommended)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ A blazing fast CLI for macOS Reminders. Sub-200ms reads AND writes via EventKit,
 
 ## Installation
 
+### Homebrew
+
+```bash
+brew tap BRO3886/tap
+brew install rem
+```
+
 ### Quick install (recommended)
 
 ```bash


### PR DESCRIPTION
A Homebrew tap (BRO3886/tap) has been set up for rem. This PR adds Homebrew install instructions to the README so users can install via `brew tap BRO3886/tap && brew install rem`.

Homebrew is placed first in the Installation section as the easiest and most familiar install path for macOS users.
