### PR TITLE
Auto-update Homebrew formula on release

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -37,24 +37,28 @@ jobs:
 
       - name: Update formula
         run: |
-          cat > homebrew-tap/Formula/rem-cli.rb << 'FORMULA'
+          VERSION="${{ steps.release.outputs.version }}"
+          TAG="${{ github.ref_name }}"
+          ARM_SHA="${{ steps.checksums.outputs.arm64_sha }}"
+          AMD_SHA="${{ steps.checksums.outputs.amd64_sha }}"
+          cat > homebrew-tap/Formula/rem-cli.rb <<EOF
           class RemCli < Formula
             desc "Blazing fast CLI for macOS Reminders — sub-200ms reads and writes via EventKit"
             homepage "https://github.com/BRO3886/rem"
-            version "${{ steps.release.outputs.version }}"
+            version "${VERSION}"
             license "MIT"
 
             depends_on :macos
-            conflicts_with "rem", because: "both install a `rem` binary"
+            conflicts_with "rem", because: "both install a \\\`rem\\\` binary"
 
             on_arm do
-              url "https://github.com/BRO3886/rem/releases/download/${{ github.ref_name }}/rem-darwin-arm64.tar.gz"
-              sha256 "${{ steps.checksums.outputs.arm64_sha }}"
+              url "https://github.com/BRO3886/rem/releases/download/${TAG}/rem-darwin-arm64.tar.gz"
+              sha256 "${ARM_SHA}"
             end
 
             on_intel do
-              url "https://github.com/BRO3886/rem/releases/download/${{ github.ref_name }}/rem-darwin-amd64.tar.gz"
-              sha256 "${{ steps.checksums.outputs.amd64_sha }}"
+              url "https://github.com/BRO3886/rem/releases/download/${TAG}/rem-darwin-amd64.tar.gz"
+              sha256 "${AMD_SHA}"
             end
 
             def install
@@ -62,11 +66,10 @@ jobs:
             end
 
             test do
-              assert_match version.to_s, shell_output("#{bin}/rem version")
+              assert_match version.to_s, shell_output("\#{bin}/rem version")
             end
           end
-          FORMULA
-          # Fix indentation - remove leading spaces from heredoc
+          EOF
           sed -i 's/^          //' homebrew-tap/Formula/rem-cli.rb
 
       - name: Commit and push

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,80 @@
+name: Update Homebrew formula
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-tap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for release assets
+        run: sleep 30
+
+      - name: Get release info
+        id: release
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Download and checksum
+        id: checksums
+        run: |
+          ARM_URL="https://github.com/BRO3886/rem/releases/download/${{ github.ref_name }}/rem-darwin-arm64.tar.gz"
+          AMD_URL="https://github.com/BRO3886/rem/releases/download/${{ github.ref_name }}/rem-darwin-amd64.tar.gz"
+          curl -sL "$ARM_URL" -o arm64.tar.gz
+          curl -sL "$AMD_URL" -o amd64.tar.gz
+          echo "arm64_sha=$(shasum -a 256 arm64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "amd64_sha=$(shasum -a 256 amd64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout tap
+        uses: actions/checkout@v4
+        with:
+          repository: BRO3886/homebrew-tap
+          token: ${{ secrets.TAP_GITHUB_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update formula
+        run: |
+          cat > homebrew-tap/Formula/rem-cli.rb << 'FORMULA'
+          class RemCli < Formula
+            desc "Blazing fast CLI for macOS Reminders — sub-200ms reads and writes via EventKit"
+            homepage "https://github.com/BRO3886/rem"
+            version "${{ steps.release.outputs.version }}"
+            license "MIT"
+
+            depends_on :macos
+            conflicts_with "rem", because: "both install a `rem` binary"
+
+            on_arm do
+              url "https://github.com/BRO3886/rem/releases/download/${{ github.ref_name }}/rem-darwin-arm64.tar.gz"
+              sha256 "${{ steps.checksums.outputs.arm64_sha }}"
+            end
+
+            on_intel do
+              url "https://github.com/BRO3886/rem/releases/download/${{ github.ref_name }}/rem-darwin-amd64.tar.gz"
+              sha256 "${{ steps.checksums.outputs.amd64_sha }}"
+            end
+
+            def install
+              bin.install "rem"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/rem version")
+            end
+          end
+          FORMULA
+          # Fix indentation - remove leading spaces from heredoc
+          sed -i 's/^          //' homebrew-tap/Formula/rem-cli.rb
+
+      - name: Commit and push
+        run: |
+          cd homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/rem-cli.rb
+          git diff --cached --quiet && echo "No changes" && exit 0
+          git commit -m "feat: bump rem-cli to ${{ steps.release.outputs.version }}"
+          git push


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically keeps the Homebrew formula in BRO3886/homebrew-tap in sync whenever a new release is published on this repo.

How it works:
- Triggers on `release: published` events
- Waits 30s for release assets to propagate on the CDN
- Downloads the darwin-arm64 and darwin-amd64 tarballs and computes their SHA256 checksums
- Checks out the tap repo using a `TAP_GITHUB_TOKEN` secret (needs write access to BRO3886/homebrew-tap)
- Overwrites `Formula/rem-cli.rb` with the new version, URLs, and checksums
- Commits and pushes directly to the tap's default branch

One prerequisite: add a `TAP_GITHUB_TOKEN` secret to this repo with a fine-grained PAT that has Contents: write permission on BRO3886/homebrew-tap.
