### PR TITLE
Flag and unflag reminders via native ReminderKit bridge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@
 - **Conventional Commits**: ALL commits MUST follow [Conventional Commits](https://www.conventionalcommits.org/). Format: `type(scope): description`. Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `build`, `ci`, `perf`. No exceptions.
 
 ## What is this?
-Go CLI wrapping macOS Reminders. Uses `go-eventkit` (cgo + Objective-C EventKit) for fast reads AND writes (<200ms) as a single binary — including reminder CRUD and list CRUD. AppleScript only for flagged operations and default list name query. Provides CRUD for reminders/lists, natural language dates, and import/export. For programmatic Go access, use `go-eventkit` directly.
+Go CLI wrapping macOS Reminders. Uses `go-eventkit` (cgo + Objective-C EventKit + private ReminderKit bridge) for fast reads AND writes (<200ms) as a single binary — including reminder CRUD, list CRUD, and flagged operations. AppleScript only for the default list name query. Provides CRUD for reminders/lists, natural language dates, and import/export. For programmatic Go access, use `go-eventkit` directly.
 
 ## Architecture
 - `cmd/rem/commands/` - Cobra CLI commands (one file per command); `huh_helpers.go` has shared interactive utilities
-- `internal/service/` - Service layer: `reminders.go` and `lists.go` wrap `go-eventkit` client. `executor.go` runs `osascript` for flagged operations and default list name query only.
+- `internal/service/` - Service layer: `reminders.go` and `lists.go` wrap `go-eventkit` client. `executor.go` runs `osascript` for the default list name query only.
 - `internal/reminder/` - Domain models: `Reminder`, `List`, `Priority`
 - `internal/export/` - JSON/CSV import/export
 - `internal/skills/` - Agent skill install/uninstall/status logic
@@ -19,8 +19,8 @@ Go CLI wrapping macOS Reminders. Uses `go-eventkit` (cgo + Objective-C EventKit)
 ## Critical: Architecture Rules
 - **ALL reads AND writes go through `go-eventkit`** (`github.com/BRO3886/go-eventkit/reminders`) — in-process EventKit via cgo, <200ms
 - **Single binary** — go-eventkit's cgo code compiled into the binary
-- **AppleScript only for**: flagged operations (EventKit doesn't expose flagged), default list name query
-- **EventKit doesn't expose `flagged`** - JXA fallback only used when `--flagged` filter is active, AppleScript for flag/unflag writes
+- **AppleScript only for**: default list name query (nothing else)
+- **Flagged is read/written via go-eventkit** using the private ReminderKit bridge (same mechanism as URL attachments). `EKReminder.flagged` doesn't exist, but `REMReminder.flagged` does. Read via KVC (`valueForKey:`, not `isFlagged` selector — it's a dynamic property). Write via `REMSaveRequest.updateReminder:` change item, then `changeItem.flaggedContext.setFlagged:`, then `saveSynchronouslyWithError:`. Refetch the EKReminder after save so the returned dict reflects the new value. See journal 011.
 - **go-eventkit field names**: `Title` (not `Name`), `Notes` (not `Body`), `List` (not `ListName`), native `URL` field
 - **URL field goes to `REMURLAttachment`, NOT `EKCalendarItem.URL`**: `EKCalendarItem.URL` is a public property that's disconnected from the Reminders.app UI (Apple bug/limitation). go-eventkit v0.5.0+ writes to the real UI-visible URL field via a private ReminderKit bridge (`REMSaveRequest` → `attachmentContext.setURLAttachmentWithURL:`), guarded by `respondsToSelector:` with fallback to `EKCalendarItem.URL`. See journal 009.
 - **List CRUD via go-eventkit**: `CreateList` (auto-discovers source), `UpdateList` (ID-based), `DeleteList` (ID-based). Immutable lists are rejected.

--- a/cmd/rem/commands/root.go
+++ b/cmd/rem/commands/root.go
@@ -31,7 +31,7 @@ func init() {
 		os.Exit(1)
 	}
 	exec = service.NewExecutor()
-	reminderSvc = service.NewReminderService(client, exec)
+	reminderSvc = service.NewReminderService(client)
 	listSvc = service.NewListService(client, exec)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/BRO3886/rem
 go 1.24.5
 
 require (
-	github.com/BRO3886/go-eventkit v0.5.0
+	github.com/BRO3886/go-eventkit v0.8.0
 	github.com/charmbracelet/huh v0.8.0
 	github.com/charmbracelet/x/term v0.2.1
 	github.com/fatih/color v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BRO3886/go-eventkit v0.5.0 h1:yz4JL5taYyzAlWqbeb3lK0B/Odnz7sn+UF+HjrJ+91E=
-github.com/BRO3886/go-eventkit v0.5.0/go.mod h1:672VezZhNB1eX7GOph9fGmR7d3rIP0/HrMv7fss4zAk=
+github.com/BRO3886/go-eventkit v0.8.0 h1:6WDZ69wE7McZu+swozhPunZGvzydzVEU+CzGEIRr3C8=
+github.com/BRO3886/go-eventkit v0.8.0/go.mod h1:672VezZhNB1eX7GOph9fGmR7d3rIP0/HrMv7fss4zAk=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=

--- a/internal/service/executor.go
+++ b/internal/service/executor.go
@@ -11,8 +11,8 @@ import (
 	"time"
 )
 
-// Executor runs AppleScript and JXA commands via osascript.
-// Reads are handled by the internal/eventkit package (cgo + EventKit).
+// Executor runs AppleScript commands via osascript.
+// Used only for the default list name query.
 type Executor struct {
 	timeout time.Duration
 }
@@ -20,7 +20,7 @@ type Executor struct {
 // NewExecutor creates a new Executor.
 func NewExecutor() *Executor {
 	return &Executor{
-		timeout: 120 * time.Second,
+		timeout: 30 * time.Second,
 	}
 }
 
@@ -51,79 +51,3 @@ func (e *Executor) RunContext(ctx context.Context, script string) (string, error
 	return strings.TrimSpace(stdout.String()), nil
 }
 
-// RunJXA executes a JavaScript for Automation script and returns the output.
-func (e *Executor) RunJXA(script string) (string, error) {
-	return e.RunJXAContext(context.Background(), script)
-}
-
-// RunJXAContext executes a JXA script with a context for cancellation.
-func (e *Executor) RunJXAContext(ctx context.Context, script string) (string, error) {
-	ctx, cancel := context.WithTimeout(ctx, e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "osascript", "-l", "JavaScript", "-e", script)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	if err != nil {
-		errMsg := strings.TrimSpace(stderr.String())
-		if errMsg == "" {
-			errMsg = err.Error()
-		}
-		return "", fmt.Errorf("jxa error: %s", errMsg)
-	}
-
-	return strings.TrimSpace(stdout.String()), nil
-}
-
-// EscapeString escapes a string for safe use in AppleScript.
-func EscapeString(s string) string {
-	s = strings.ReplaceAll(s, "\\", "\\\\")
-	s = strings.ReplaceAll(s, "\"", "\\\"")
-	return s
-}
-
-// EscapeJXA escapes a string for safe use in JXA JavaScript strings.
-func EscapeJXA(s string) string {
-	s = strings.ReplaceAll(s, "\\", "\\\\")
-	s = strings.ReplaceAll(s, "'", "\\'")
-	s = strings.ReplaceAll(s, "\"", "\\\"")
-	s = strings.ReplaceAll(s, "\n", "\\n")
-	s = strings.ReplaceAll(s, "\r", "\\r")
-	return s
-}
-
-// FormatDate formats a Go time.Time into an AppleScript date construction string.
-func FormatDate(t time.Time) string {
-	return fmt.Sprintf(`(current date) + 0
-set year of result to %d
-set month of result to %d
-set day of result to %d
-set hours of result to %d
-set minutes of result to %d
-set seconds of result to %d
-set theDate to result`,
-		t.Year(), int(t.Month()), t.Day(),
-		t.Hour(), t.Minute(), t.Second())
-}
-
-// FormatDateInline creates a self-contained AppleScript date expression
-// that can be used inline in property lists.
-func FormatDateInline(varName string, t time.Time) string {
-	return fmt.Sprintf(`set %s to current date
-set year of %s to %d
-set month of %s to %d
-set day of %s to %d
-set hours of %s to %d
-set minutes of %s to %d
-set seconds of %s to %d`,
-		varName,
-		varName, t.Year(),
-		varName, int(t.Month()),
-		varName, t.Day(),
-		varName, t.Hour(),
-		varName, t.Minute(),
-		varName, t.Second())
-}

--- a/internal/service/reminders.go
+++ b/internal/service/reminders.go
@@ -3,10 +3,8 @@
 package service
 
 import (
-	"encoding/json"
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	eventkit "github.com/BRO3886/go-eventkit"
@@ -15,15 +13,15 @@ import (
 )
 
 // ReminderService provides operations for reminders using go-eventkit for
-// reads and writes, with AppleScript fallback for flagged operations.
+// all reads and writes, including flagged operations via the private
+// ReminderKit bridge.
 type ReminderService struct {
 	client *reminders.Client
-	exec   *Executor
 }
 
 // NewReminderService creates a new ReminderService.
-func NewReminderService(client *reminders.Client, exec *Executor) *ReminderService {
-	return &ReminderService{client: client, exec: exec}
+func NewReminderService(client *reminders.Client) *ReminderService {
+	return &ReminderService{client: client}
 }
 
 // CreateReminder creates a new reminder and returns its ID.
@@ -48,6 +46,10 @@ func (s *ReminderService) CreateReminder(r *reminder.Reminder) (string, error) {
 		input.URL = r.URL
 	}
 
+	if r.Flagged {
+		input.Flagged = true
+	}
+
 	for _, a := range r.Alarms {
 		input.Alarms = append(input.Alarms, reminders.Alarm{
 			AbsoluteDate:   a.AbsoluteDate,
@@ -62,11 +64,6 @@ func (s *ReminderService) CreateReminder(r *reminder.Reminder) (string, error) {
 	created, err := s.client.CreateReminder(input)
 	if err != nil {
 		return "", fmt.Errorf("failed to create reminder: %w", err)
-	}
-
-	// Set flagged via AppleScript if needed (EventKit can't set flagged)
-	if r.Flagged {
-		_ = s.FlagReminder(created.ID)
 	}
 
 	return created.ID, nil
@@ -108,27 +105,16 @@ func (s *ReminderService) ListReminders(filter *reminder.ListFilter) ([]*reminde
 		return nil, fmt.Errorf("failed to list reminders: %w", err)
 	}
 
-	// Apply flagged filter — EventKit doesn't expose flagged, so we need
-	// JXA fallback when --flagged is active.
+	// Apply flagged filter — go-eventkit reads the flagged property via the
+	// private ReminderKit bridge, so it's already populated on each Reminder.
 	needsFlagged := filter != nil && filter.Flagged != nil && *filter.Flagged
-
-	var flaggedIDs map[string]bool
-	if needsFlagged {
-		flaggedIDs, err = s.fetchFlaggedIDs()
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	result := make([]*reminder.Reminder, 0, len(ekReminders))
 	for i := range ekReminders {
 		r := fromEventKitReminder(&ekReminders[i])
 
-		if needsFlagged {
-			r.Flagged = flaggedIDs[r.ID]
-			if !r.Flagged {
-				continue
-			}
+		if needsFlagged && !r.Flagged {
+			continue
 		}
 
 		result = append(result, r)
@@ -168,47 +154,9 @@ func sortReminders(result []*reminder.Reminder) {
 	})
 }
 
-// fetchFlaggedIDs uses JXA to get the set of flagged reminder IDs.
-func (s *ReminderService) fetchFlaggedIDs() (map[string]bool, error) {
-	script := `
-const app = Application('Reminders');
-const lists = app.lists();
-const result = [];
-for (const list of lists) {
-	const n = list.reminders.length;
-	if (n === 0) continue;
-	const ids = list.reminders.id();
-	const flagged = list.reminders.flagged();
-	for (let i = 0; i < n; i++) {
-		if (flagged[i]) result.push(ids[i]);
-	}
-}
-JSON.stringify(result);`
-
-	output, err := s.exec.RunJXA(script)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch flagged status: %w", err)
-	}
-
-	var ids []string
-	if output != "" && output != "[]" {
-		if err := json.Unmarshal([]byte(output), &ids); err != nil {
-			return nil, fmt.Errorf("failed to parse flagged IDs: %w", err)
-		}
-	}
-
-	m := make(map[string]bool, len(ids))
-	for _, id := range ids {
-		m[id] = true
-	}
-	return m, nil
-}
-
 // UpdateReminder updates properties of an existing reminder.
 func (s *ReminderService) UpdateReminder(id string, updates map[string]any) error {
 	input := reminders.UpdateReminderInput{}
-	var needsAppleScript bool
-	var appleScriptUpdates map[string]any
 
 	for key, value := range updates {
 		switch key {
@@ -238,12 +186,8 @@ func (s *ReminderService) UpdateReminder(id string, updates map[string]any) erro
 			p := reminders.Priority(value.(reminder.Priority))
 			input.Priority = &p
 		case "flagged":
-			// EventKit can't set flagged — use AppleScript
-			needsAppleScript = true
-			if appleScriptUpdates == nil {
-				appleScriptUpdates = make(map[string]any)
-			}
-			appleScriptUpdates["flagged"] = value
+			v := value.(bool)
+			input.Flagged = &v
 		case "completed":
 			v := value.(bool)
 			input.Completed = &v
@@ -283,55 +227,11 @@ func (s *ReminderService) UpdateReminder(id string, updates map[string]any) erro
 		}
 	}
 
-	// Apply EventKit updates (all fields except flagged)
-	hasEventKitUpdates := input.Title != nil || input.Notes != nil ||
-		input.DueDate != nil || input.ClearDueDate ||
-		input.RemindMeDate != nil || input.Priority != nil ||
-		input.Completed != nil || input.URL != nil || input.ListName != nil ||
-		input.Alarms != nil || input.RecurrenceRules != nil
-
-	if hasEventKitUpdates {
-		if _, err := s.client.UpdateReminder(id, input); err != nil {
-			return fmt.Errorf("failed to update reminder: %w", err)
-		}
-	}
-
-	// Apply AppleScript updates (flagged)
-	if needsAppleScript {
-		if err := s.updateViaAppleScript(id, appleScriptUpdates); err != nil {
-			return fmt.Errorf("failed to update reminder flags: %w", err)
-		}
+	if _, err := s.client.UpdateReminder(id, input); err != nil {
+		return fmt.Errorf("failed to update reminder: %w", err)
 	}
 
 	return nil
-}
-
-// updateViaAppleScript updates reminder properties that EventKit doesn't support.
-func (s *ReminderService) updateViaAppleScript(id string, updates map[string]any) error {
-	var setStatements []string
-
-	for key, value := range updates {
-		switch key {
-		case "flagged":
-			if value.(bool) {
-				setStatements = append(setStatements, `set flagged of r to true`)
-			} else {
-				setStatements = append(setStatements, `set flagged of r to false`)
-			}
-		}
-	}
-
-	if len(setStatements) == 0 {
-		return nil
-	}
-
-	script := fmt.Sprintf(`tell application "Reminders"
-	set r to first reminder whose id is "%s"
-	%s
-end tell`, EscapeString(id), strings.Join(setStatements, "\n\t"))
-
-	_, err := s.exec.Run(script)
-	return err
 }
 
 // DeleteReminder deletes a reminder by ID.
@@ -364,14 +264,22 @@ func (s *ReminderService) UncompleteReminder(id string) error {
 	return nil
 }
 
-// FlagReminder flags a reminder via AppleScript (EventKit doesn't support flagged).
+// FlagReminder flags a reminder via the private ReminderKit bridge.
 func (s *ReminderService) FlagReminder(id string) error {
-	return s.updateViaAppleScript(id, map[string]any{"flagged": true})
+	flagged := true
+	if _, err := s.client.UpdateReminder(id, reminders.UpdateReminderInput{Flagged: &flagged}); err != nil {
+		return fmt.Errorf("failed to flag reminder: %w", err)
+	}
+	return nil
 }
 
-// UnflagReminder removes the flag from a reminder via AppleScript.
+// UnflagReminder removes the flag from a reminder via the private ReminderKit bridge.
 func (s *ReminderService) UnflagReminder(id string) error {
-	return s.updateViaAppleScript(id, map[string]any{"flagged": false})
+	flagged := false
+	if _, err := s.client.UpdateReminder(id, reminders.UpdateReminderInput{Flagged: &flagged}); err != nil {
+		return fmt.Errorf("failed to unflag reminder: %w", err)
+	}
+	return nil
 }
 
 // toEventKitRecurrenceRule converts a domain RecurrenceRule to an eventkit RecurrenceRule.


### PR DESCRIPTION
## Summary

- Replace all AppleScript/JXA flagged operations with native go-eventkit calls via the private ReminderKit bridge
- `FlagReminder`/`UnflagReminder` now go through `client.UpdateReminder` with `Flagged *bool`
- `CreateReminder` sets `Flagged` directly on `CreateReminderInput` (no second round-trip)
- `ListReminders` reads `r.Flagged` populated by go-eventkit (KVC on `REMReminder`) — no separate `fetchFlaggedIDs()` JXA call
- Remove `fetchFlaggedIDs()`, `updateViaAppleScript()`, and the AppleScript split-path in `UpdateReminder`
- Drop unused `Executor` dependency from `ReminderService`
- Bump go-eventkit to v0.8.0, drop local `replace` directive

Net: -120 lines, +28 lines. All flagged operations are now <200ms in-process calls.

## Test plan

- [x] `go test ./...` — 180 tests pass
- [x] `make build` — clean
- [x] `rem add "test" --flagged` → created with `flagged: true`
- [x] `rem unflag <id>` → `flagged: false` on refetch
- [x] `rem flag <id>` → `flagged: true` on refetch
- [x] `rem update <id> --flagged false` → `flagged: false` on refetch
- [x] `rem list --flagged` → returns only flagged reminders
- [x] `rem add "test" --flagged --due "tomorrow 9am" --url "..." --priority high` → all fields set correctly
- [x] `rem add "test"` (no --flagged) → `flagged: false` (default preserved)
- [x] Cleanup: `rem delete` works on flagged reminders
