### PR TITLE
Update docs for ReminderKit bridge flagged operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ make build
 
 ## Requirements
 
-- macOS 13+ (uses EventKit for all reads and writes via go-eventkit, AppleScript only for flagged operations)
+- macOS 13+ (uses EventKit + private ReminderKit bridge for all reads and writes via go-eventkit, AppleScript only for default list name query)
 - Xcode Command Line Tools (for building from source — cgo/clang + framework headers)
 - First run will prompt for Reminders app access in System Settings > Privacy & Security
 
@@ -315,7 +315,7 @@ rem/
 │   ├── main.go
 │   └── commands/         # Cobra command definitions
 ├── internal/
-│   ├── service/          # Service layer wrapping go-eventkit (AppleScript only for flagged ops)
+│   ├── service/          # Service layer wrapping go-eventkit (AppleScript only for default list name)
 │   ├── reminder/         # Domain models (Reminder, List, Priority)
 │   ├── export/           # JSON & CSV import/export
 │   ├── skills/           # Agent skill install/uninstall/status
@@ -330,7 +330,7 @@ rem/
 
 **All reads and writes** — including reminder CRUD and list CRUD — go through `go-eventkit` (`github.com/BRO3886/go-eventkit`) — an Objective-C EventKit bridge compiled into the binary via cgo. Direct in-process access to the Reminders store, no IPC. All operations complete in under 200ms.
 
-**Flagged operations** use AppleScript via `osascript` — EventKit doesn't expose the flagged property. Default list name query also uses AppleScript.
+**Flagged operations** use the private ReminderKit bridge in go-eventkit — EventKit doesn't expose the flagged property, but `REMReminder.flagged` does. AppleScript is only used for the default list name query.
 
 ## Performance
 
@@ -350,7 +350,7 @@ See [Performance docs](https://rem.sidv.dev/docs/performance/) for the full opti
 
 - **macOS only** — requires EventKit framework and osascript
 - **No tags/subtasks** — not exposed via EventKit
-- **`--flagged` filter is slow** (~3-4s) — EventKit doesn't expose `flagged`, falls back to JXA
+- **`flagged` uses private API** — reads/writes via ReminderKit bridge, may break on future macOS versions
 - **Immutable lists** cannot be renamed or deleted (system lists like Siri suggestions)
 
 ## License

--- a/skills/rem-cli/SKILL.md
+++ b/skills/rem-cli/SKILL.md
@@ -112,7 +112,7 @@ rem update AB12 --url ""    # clear
 1. **macOS only.** rem uses EventKit via cgo. Will fail on Linux — detect OS first if you're unsure.
 2. **Priority uses word forms, not raw numbers.** Pass `--priority high|medium|low|none`. rem does accept raw ints, but Apple's 1–9 scale is inverted (1 = highest, 9 = lowest), so the words are safer when relaying from user input.
 3. **`--due none` clears** the due date in `rem update`. Same for `--remind-me none` and `--repeat none`.
-4. **The `--flagged` filter is slower (~3–4s)** because EventKit doesn't expose the flagged property, so rem falls back to JXA for that filter only. All other operations are sub-200ms.
+4. **Flagged uses private API.** Reads/writes go through Apple's private ReminderKit framework since EventKit doesn't expose the flagged property. Sub-200ms like everything else, but may break on future macOS versions.
 5. **`rem delete` prompts by default.** Pass `--force` / `--yes` / `-y` when scripting to skip the confirmation.
 6. **`rem add -i` (interactive form) has no `--silent` equivalent.** If a user wants a silent reminder via the interactive flow, create it normally and then run `rem update <id> --remind-me none` to clear the alarm.
 7. **Old reminders with URLs in the notes body** (`URL: https://...`) still read correctly as a backward-compat fallback. New reminders always use the native URL field.

--- a/website/content/docs/architecture.md
+++ b/website/content/docs/architecture.md
@@ -16,7 +16,7 @@ sitemap:
 
 ## Overview
 
-rem uses **go-eventkit** (`github.com/BRO3886/go-eventkit`) for all reads and writes — including reminder CRUD and list CRUD — via EventKit's cgo bridge. AppleScript is only used for flagged operations and default list name queries that EventKit doesn't support.
+rem uses **go-eventkit** (`github.com/BRO3886/go-eventkit`) for all reads and writes — including reminder CRUD, list CRUD, and flagged operations — via EventKit's cgo bridge and a private ReminderKit bridge. AppleScript is only used for the default list name query.
 
 <div class="arch-diagram">
   <div class="arch-layer">
@@ -46,7 +46,7 @@ rem uses **go-eventkit** (`github.com/BRO3886/go-eventkit`) for all reads and wr
       <span class="arch-label">AppleScript Path</span>
       <span class="arch-sublabel">osascript fallback</span>
       <span class="arch-detail">internal/service/</span>
-      <span class="arch-file">flagged, default list</span>
+      <span class="arch-file">default list name only</span>
     </div>
   </div>
   <div class="arch-arrow">&#8595;</div>
@@ -95,16 +95,20 @@ JXA (JavaScript for Automation) was rem's original read layer. Each property acc
 
 EventKit is an in-process framework — direct memory access to the reminder store with no IPC. Result: **0.13 seconds** for the same dataset. That's a **462x speedup**.
 
+## Private ReminderKit bridge
+
+EventKit's `EKReminder` does not expose a `flagged` property or the real URL field visible in Reminders.app. go-eventkit bridges these through Apple's private `ReminderKit.framework`:
+
+- **Flagged** — read via KVC (`valueForKey:@"flagged"` on `REMReminder`), write via `REMSaveRequest` → `flaggedContext.setFlagged:`
+- **URL attachments** — write via `REMSaveRequest` → `attachmentContext.setURLAttachmentWithURL:`
+
+Both operations complete in under 200ms, the same as all other EventKit operations. All private API calls are guarded by `respondsToSelector:` checks and will fail cleanly if Apple removes them in a future macOS version.
+
 ## AppleScript fallback
 
-Two operations still use AppleScript via `osascript`:
+One operation still uses AppleScript via `osascript`:
 
-1. **Flag/unflag reminders** — EventKit doesn't expose the `flagged` property
-2. **Default list name** — not exposed by go-eventkit
-
-### The flagged exception
-
-EventKit's `EKReminder` does not expose a `flagged` property. When the `--flagged` filter is active, rem falls back to JXA to fetch flagged reminder IDs. This is the only remaining slow path (~3-4 seconds) but is rarely used. Flag/unflag write operations use AppleScript.
+1. **Default list name** — not exposed by EventKit or go-eventkit
 
 ## Single binary
 
@@ -116,8 +120,8 @@ This means `go install github.com/BRO3886/rem/cmd/rem@latest` works out of the b
 
 ```
 internal/
-├── service/               # Service layer (go-eventkit + AppleScript for flagged only)
-│   ├── executor.go        # Runs osascript (flagged ops, default list name)
+├── service/               # Service layer (go-eventkit + AppleScript for default list name only)
+│   ├── executor.go        # Runs osascript (default list name query)
 │   ├── reminders.go       # ReminderService wrapping go-eventkit
 │   ├── lists.go           # ListService wrapping go-eventkit
 │   └── parser.go          # Backward-compat URL extraction from notes body (fallback reader)
@@ -139,7 +143,7 @@ rem uses five external Go dependencies:
 
 | Package | Purpose |
 |---------|---------|
-| `BRO3886/go-eventkit` v0.5.0+ | Native EventKit bindings (cgo + ObjC, reads AND writes). Includes the private ReminderKit bridge for the native URL field. |
+| `BRO3886/go-eventkit` v0.8.0+ | Native EventKit bindings (cgo + ObjC, reads AND writes). Includes the private ReminderKit bridge for flagged state and URL attachments. |
 | `spf13/cobra` | CLI framework (commands, flags, help) |
 | `olekukonko/tablewriter` | Terminal table formatting |
 | `fatih/color` | Terminal colors |

--- a/website/content/docs/commands.md
+++ b/website/content/docs/commands.md
@@ -253,7 +253,7 @@ rem lm rename "Projects" "Active Projects"
 rem lm delete "Old List" --force
 ```
 
-> Note: List deletion may fail on some macOS versions due to AppleScript limitations.
+> Note: Immutable system lists (e.g. Siri suggestions) cannot be renamed or deleted.
 
 ## Import & Export
 

--- a/website/content/docs/performance.md
+++ b/website/content/docs/performance.md
@@ -30,7 +30,7 @@ Every read command completes in under 200ms. Tested with 224 reminders across 12
 | `rem upcoming` | 0.12s |
 | `rem export --format json` | 0.13s |
 
-All write operations — including reminder CRUD and list CRUD — go through EventKit via go-eventkit, completing in under 200ms. Only flagged operations still use AppleScript (~0.5s).
+All operations — including reminder CRUD, list CRUD, and flagged read/write — go through EventKit and the private ReminderKit bridge via go-eventkit, completing in under 200ms.
 
 ## The optimization journey
 
@@ -74,7 +74,11 @@ Extracted the EventKit bridge into a standalone library (`github.com/BRO3886/go-
 
 ### Stage 6: go-eventkit list CRUD (full EventKit coverage)
 
-go-eventkit v0.2.1 added list CRUD support (create, rename/recolor, delete). rem now uses EventKit for all list operations too, eliminating the last AppleScript dependency for CRUD. AppleScript is now only used for flagged operations (EventKit limitation) and default list name queries.
+go-eventkit v0.2.1 added list CRUD support (create, rename/recolor, delete). rem now uses EventKit for all list operations too.
+
+### Stage 7: go-eventkit private ReminderKit bridge (no more slow paths)
+
+go-eventkit v0.8.0 added flagged read/write via the private ReminderKit framework. EventKit's `EKReminder` doesn't expose a `flagged` property, but `REMReminder.flagged` does — go-eventkit reads it via KVC and writes via `REMSaveRequest`. This eliminated the last AppleScript/JXA slow path. AppleScript is now only used for the default list name query.
 
 ## Before vs after
 
@@ -111,8 +115,8 @@ JXA/AppleScript, by contrast, sends Apple Events to the Reminders.app process. E
 
 ## Writes are now fast too
 
-Since the migration to go-eventkit, all write operations — including reminder CRUD and list CRUD — go through EventKit and complete in under 200ms. Only flagged operations still use AppleScript (~0.5s).
+Since the migration to go-eventkit, all operations — including reminder CRUD, list CRUD, and flagged read/write — go through EventKit and the private ReminderKit bridge, completing in under 200ms.
 
-## Known slow path
+## No remaining slow paths
 
-The `--flagged` filter falls back to JXA because EventKit's `EKReminder` doesn't expose a `flagged` property. This takes ~3-4 seconds. All other reads use EventKit and complete in under 200ms.
+As of go-eventkit v0.8.0, all operations complete in under 200ms. The `--flagged` filter previously fell back to JXA (~3-4 seconds), but now reads the flagged property directly via the private ReminderKit bridge. The only remaining AppleScript call is for the default list name query.


### PR DESCRIPTION
## Summary

- Remove stale references to AppleScript/JXA for flagged operations across all docs
- Document the private ReminderKit bridge in the architecture page (flagged + URL attachments)
- Add Stage 7 to the performance optimization journey (no more slow paths)
- Update the known limitations in README (private API risk instead of slow JXA)
- Fix stale "AppleScript limitations" note on list deletion in commands page
- Update agent skill gotcha to reflect sub-200ms flagged ops via private API

## Files changed

- `README.md` — requirements, architecture tree, known limitations
- `website/content/docs/architecture.md` — overview, diagram, fallback section, project structure, dependencies
- `website/content/docs/performance.md` — summary, Stage 7, writes section, known slow path → no remaining slow paths
- `website/content/docs/commands.md` — list deletion note
- `skills/rem-cli/SKILL.md` — flagged gotcha
