### PR TITLE
Graceful degradation for flagged state via two-step create and update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/BRO3886/rem
 go 1.24.5
 
 require (
-	github.com/BRO3886/go-eventkit v0.9.0
+	github.com/BRO3886/go-eventkit v0.10.0
 	github.com/charmbracelet/huh v0.8.0
 	github.com/charmbracelet/x/term v0.2.1
 	github.com/fatih/color v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BRO3886/go-eventkit v0.9.0 h1:v2aRrKFqUGTQuHjpFQDCFgr9ZN23YaVLE9BvMTXY9fw=
-github.com/BRO3886/go-eventkit v0.9.0/go.mod h1:672VezZhNB1eX7GOph9fGmR7d3rIP0/HrMv7fss4zAk=
+github.com/BRO3886/go-eventkit v0.10.0 h1:sZUp6qyP2q89ERzl1xhcR5jJM7Zi2HVZvGEEt/+fyNU=
+github.com/BRO3886/go-eventkit v0.10.0/go.mod h1:672VezZhNB1eX7GOph9fGmR7d3rIP0/HrMv7fss4zAk=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=

--- a/internal/service/reminders.go
+++ b/internal/service/reminders.go
@@ -47,10 +47,6 @@ func (s *ReminderService) CreateReminder(r *reminder.Reminder) (string, error) {
 		input.URL = r.URL
 	}
 
-	if r.Flagged {
-		input.Flagged = true
-	}
-
 	for _, a := range r.Alarms {
 		input.Alarms = append(input.Alarms, reminders.Alarm{
 			AbsoluteDate:   a.AbsoluteDate,
@@ -72,6 +68,14 @@ func (s *ReminderService) CreateReminder(r *reminder.Reminder) (string, error) {
 		_, err := s.client.UpdateReminder(created.ID, reminders.UpdateReminderInput{Tags: &tags})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: reminder created but tags could not be saved (private API may be unavailable)\n")
+		}
+	}
+
+	if r.Flagged {
+		flagged := true
+		_, err := s.client.UpdateReminder(created.ID, reminders.UpdateReminderInput{Flagged: &flagged})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: reminder created but flag could not be saved (private API may be unavailable)\n")
 		}
 	}
 
@@ -169,6 +173,7 @@ func sortReminders(result []*reminder.Reminder) {
 // UpdateReminder updates properties of an existing reminder.
 func (s *ReminderService) UpdateReminder(id string, updates map[string]any) error {
 	var pendingTags *[]string
+	var pendingFlagged *bool
 	input := reminders.UpdateReminderInput{}
 
 	for key, value := range updates {
@@ -200,7 +205,7 @@ func (s *ReminderService) UpdateReminder(id string, updates map[string]any) erro
 			input.Priority = &p
 		case "flagged":
 			v := value.(bool)
-			input.Flagged = &v
+			pendingFlagged = &v
 		case "completed":
 			v := value.(bool)
 			input.Completed = &v
@@ -256,6 +261,13 @@ func (s *ReminderService) UpdateReminder(id string, updates map[string]any) erro
 		_, err := s.client.UpdateReminder(id, reminders.UpdateReminderInput{Tags: pendingTags})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: reminder updated but tags could not be saved (private API may be unavailable)\n")
+		}
+	}
+
+	if pendingFlagged != nil {
+		_, err := s.client.UpdateReminder(id, reminders.UpdateReminderInput{Flagged: pendingFlagged})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: reminder updated but flag could not be saved (private API may be unavailable)\n")
 		}
 	}
 

--- a/internal/service/reminders.go
+++ b/internal/service/reminders.go
@@ -304,22 +304,18 @@ func (s *ReminderService) UncompleteReminder(id string) error {
 	return nil
 }
 
-// FlagReminder flags a reminder via the private ReminderKit bridge.
+// FlagReminder flags a reminder. It routes through UpdateReminder so the
+// flagged write degrades identically to `add`/`update --flagged`: a genuine
+// error (e.g. reminder not found) is fatal, but if only the private ReminderKit
+// flagged write fails, it warns on stderr and still succeeds.
 func (s *ReminderService) FlagReminder(id string) error {
-	flagged := true
-	if _, err := s.client.UpdateReminder(id, reminders.UpdateReminderInput{Flagged: &flagged}); err != nil {
-		return fmt.Errorf("failed to flag reminder: %w", err)
-	}
-	return nil
+	return s.UpdateReminder(id, map[string]any{"flagged": true})
 }
 
-// UnflagReminder removes the flag from a reminder via the private ReminderKit bridge.
+// UnflagReminder removes the flag from a reminder. See FlagReminder for the
+// shared degradation behavior.
 func (s *ReminderService) UnflagReminder(id string) error {
-	flagged := false
-	if _, err := s.client.UpdateReminder(id, reminders.UpdateReminderInput{Flagged: &flagged}); err != nil {
-		return fmt.Errorf("failed to unflag reminder: %w", err)
-	}
-	return nil
+	return s.UpdateReminder(id, map[string]any{"flagged": false})
 }
 
 // toEventKitRecurrenceRule converts a domain RecurrenceRule to an eventkit RecurrenceRule.


### PR DESCRIPTION
Closes #44.

## What

Apply the same two-step graceful-degradation pattern used for tags (#42/#43) to **flagged** state.

- **Create**: the reminder is created with core fields only (no flagged), then flagged is set via a separate `UpdateReminder` call. If that fails, a warning is printed to stderr and the create still succeeds.
- **Update**: flagged is split out of the updates map into a `pendingFlagged`, the core update runs first, then flagged is applied separately. On failure, warn and return success — the other field updates are not lost.

This keeps rem in control of the user-facing degradation policy across all private-ReminderKit features (flagged, tags, URL), rather than relying on the bridge to silently drop the flag.

## Why this needs go-eventkit v0.10.0

Previously the go-eventkit bridge swallowed `write_flagged` failures silently, so rem had no way to detect that the flag was dropped. go-eventkit v0.10.0 (BRO3886/go-eventkit#12) makes the **update path** surface an error on failure, which is what the two-step pattern relies on. The create path in go-eventkit intentionally stays silent (erroring there would orphan an already-saved reminder); rem's two-step routes create-flagged through `UpdateReminder`, so it still gets the warning.

## Behavior note

`rem flag` / `rem unflag` are left as **hard-fail** (exit 1) on private-API unavailability — they are single-purpose commands, so failing honestly is correct. Only the multi-field `add` / `update` flows degrade gracefully, so a flagged failure never discards the other fields.

## Testing

Verified end-to-end against the released go-eventkit v0.10.0:
- Happy path: `add --flagged` → flagged, `update --flagged false` → unflagged, `flag` → flagged.
- Forced-failure (private API made to fail during development): `add --flagged` and `update --flagged` both create/update the reminder, warn on stderr, and exit 0 with the flag dropped; `rem flag` hard-fails with a clear message.
- `go test ./...` passes.
