### PR TITLE
Multi-ID mutations and agent-efficient skill guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ Release steps in order — do not skip or reorder:
 ## Conventions
 - Short IDs displayed as first 8 chars of full `x-apple-reminder://UUID` ID
 - Prefix matching: users can pass partial IDs to any command
+- **Multi-ID mutations**: `complete`, `uncomplete`, `flag`, `unflag`, `delete` all accept multiple IDs. Shared helper `runBatchAction` in `cmd/rem/commands/batch.go` resolves all IDs before mutating (fail-fast on a bad ID), continues past per-item errors, exits non-zero if any failed
 - All commands support `-o json|table|plain`
 - `NO_COLOR` env var respected
 - **Interactive mode (`-i`)**: All mutation commands (add, complete, delete, flag, unflag, update, list-mgmt create/rename/delete) support `-i` for huh-based interactive forms. Shared helpers in `huh_helpers.go`. Theme: `ThemeCatppuccin()`. All handle `ErrUserAborted` gracefully.

--- a/README.md
+++ b/README.md
@@ -120,14 +120,14 @@ rem get <id> -o json
 # Update
 rem update <id> [--name TEXT] [--due DATE] [--priority LEVEL] [--notes TEXT] [--url URL] [--add-tags TAGS] [--remove-tags TAGS] [--remind-me DURATION] [--repeat PATTERN] [--list LIST]
 
-# Complete / Uncomplete
-rem complete <id>
+# Complete / Uncomplete (support multiple IDs)
+rem complete <id> [id2 id3...]
 rem done <id>                       # Alias
-rem uncomplete <id>
+rem uncomplete <id> [id2 id3...]
 
-# Flag / Unflag
-rem flag <id>
-rem unflag <id>
+# Flag / Unflag (support multiple IDs)
+rem flag <id> [id2 id3...]
+rem unflag <id> [id2 id3...]
 
 # Delete (supports multiple IDs)
 rem delete <id> [id2 id3...]        # Asks for confirmation

--- a/cmd/rem/commands/batch.go
+++ b/cmd/rem/commands/batch.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"fmt"
+)
+
+type batchTarget struct {
+	id   string
+	name string
+}
+
+// runBatchAction resolves each arg to a reminder, applies fn to each, and
+// prints "<verb>: <name>" per success. All IDs are resolved before any
+// mutation so a typo'd ID fails the whole command instead of half-applying.
+func runBatchAction(args []string, verb string, fn func(id string) error) error {
+	var targets []batchTarget
+	for _, arg := range args {
+		r, err := findReminderByID(arg)
+		if err != nil {
+			return err
+		}
+		targets = append(targets, batchTarget{id: r.ID, name: r.Name})
+	}
+	return applyBatch(targets, verb, fn)
+}
+
+func applyBatch(targets []batchTarget, verb string, fn func(id string) error) error {
+	if len(targets) == 1 {
+		if err := fn(targets[0].id); err != nil {
+			return err
+		}
+		fmt.Printf("%s: %s\n", verb, targets[0].name)
+		return nil
+	}
+
+	var failed int
+	for _, t := range targets {
+		if err := fn(t.id); err != nil {
+			failed++
+			fmt.Printf("Error: %s: %v\n", t.name, err)
+			continue
+		}
+		fmt.Printf("%s: %s\n", verb, t.name)
+	}
+	if failed > 0 {
+		return fmt.Errorf("%d of %d failed", failed, len(targets))
+	}
+	return nil
+}

--- a/cmd/rem/commands/batch_test.go
+++ b/cmd/rem/commands/batch_test.go
@@ -1,0 +1,76 @@
+package commands
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestApplyBatchSingleSuccess(t *testing.T) {
+	var called []string
+	err := applyBatch([]batchTarget{{id: "a", name: "A"}}, "Completed", func(id string) error {
+		called = append(called, id)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(called) != 1 || called[0] != "a" {
+		t.Fatalf("expected fn called with [a], got %v", called)
+	}
+}
+
+func TestApplyBatchSingleFailureReturnsRawError(t *testing.T) {
+	sentinel := errors.New("boom")
+	err := applyBatch([]batchTarget{{id: "a", name: "A"}}, "Completed", func(id string) error {
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected raw sentinel error for single target, got %v", err)
+	}
+}
+
+func TestApplyBatchMultiSuccess(t *testing.T) {
+	var called []string
+	targets := []batchTarget{{id: "a", name: "A"}, {id: "b", name: "B"}, {id: "c", name: "C"}}
+	err := applyBatch(targets, "Flagged", func(id string) error {
+		called = append(called, id)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(called) != 3 || called[0] != "a" || called[1] != "b" || called[2] != "c" {
+		t.Fatalf("expected fn called with [a b c] in order, got %v", called)
+	}
+}
+
+func TestApplyBatchMultiPartialFailureContinues(t *testing.T) {
+	var called []string
+	targets := []batchTarget{{id: "a", name: "A"}, {id: "b", name: "B"}, {id: "c", name: "C"}}
+	err := applyBatch(targets, "Completed", func(id string) error {
+		called = append(called, id)
+		if id == "b" {
+			return errors.New("boom")
+		}
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected error for partial failure")
+	}
+	if got, want := err.Error(), "1 of 3 failed"; got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+	if len(called) != 3 {
+		t.Fatalf("expected all 3 targets attempted despite failure, got %v", called)
+	}
+}
+
+func TestApplyBatchEmptyTargets(t *testing.T) {
+	err := applyBatch(nil, "Completed", func(id string) error {
+		t.Fatal("fn should not be called")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cmd/rem/commands/complete.go
+++ b/cmd/rem/commands/complete.go
@@ -16,10 +16,11 @@ var (
 )
 
 var completeCmd = &cobra.Command{
-	Use:     "complete [id]",
+	Use:     "complete [id...]",
 	Aliases: []string{"done"},
-	Short:   "Mark a reminder as complete",
+	Short:   "Mark one or more reminders as complete",
 	Example: `  rem complete abc12345
+  rem complete abc12345 def67890
   rem done abc12345
   rem complete -i
   rem complete -i --list Work --flagged`,
@@ -27,55 +28,34 @@ var completeCmd = &cobra.Command{
 		if completeInteractive {
 			return cobra.MaximumNArgs(0)(cmd, args)
 		}
-		return cobra.ExactArgs(1)(cmd, args)
+		return cobra.MinimumNArgs(1)(cmd, args)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if completeInteractive {
 			return runCompleteInteractive(false)
 		}
-
-		r, err := findReminderByID(args[0])
-		if err != nil {
-			return err
-		}
-
-		if err := reminderSvc.CompleteReminder(r.ID); err != nil {
-			return err
-		}
-
-		fmt.Printf("Completed: %s\n", r.Name)
-		return nil
+		return runBatchAction(args, "Completed", reminderSvc.CompleteReminder)
 	},
 }
 
 var uncompleteCmd = &cobra.Command{
-	Use:   "uncomplete [id]",
-	Short: "Mark a reminder as incomplete",
+	Use:   "uncomplete [id...]",
+	Short: "Mark one or more reminders as incomplete",
 	Example: `  rem uncomplete abc12345
+  rem uncomplete abc12345 def67890
   rem uncomplete -i
   rem uncomplete -i --list Work`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if uncompleteInteractive {
 			return cobra.MaximumNArgs(0)(cmd, args)
 		}
-		return cobra.ExactArgs(1)(cmd, args)
+		return cobra.MinimumNArgs(1)(cmd, args)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if uncompleteInteractive {
 			return runCompleteInteractive(true)
 		}
-
-		r, err := findReminderByID(args[0])
-		if err != nil {
-			return err
-		}
-
-		if err := reminderSvc.UncompleteReminder(r.ID); err != nil {
-			return err
-		}
-
-		fmt.Printf("Marked incomplete: %s\n", r.Name)
-		return nil
+		return runBatchAction(args, "Marked incomplete", reminderSvc.UncompleteReminder)
 	},
 }
 

--- a/cmd/rem/commands/flag.go
+++ b/cmd/rem/commands/flag.go
@@ -15,64 +15,44 @@ var (
 )
 
 var flagCmd = &cobra.Command{
-	Use:   "flag [id]",
-	Short: "Flag a reminder",
+	Use:   "flag [id...]",
+	Short: "Flag one or more reminders",
 	Example: `  rem flag abc12345
+  rem flag abc12345 def67890
   rem flag -i
   rem flag -i --list Work`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if flagInteractive {
 			return cobra.MaximumNArgs(0)(cmd, args)
 		}
-		return cobra.ExactArgs(1)(cmd, args)
+		return cobra.MinimumNArgs(1)(cmd, args)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if flagInteractive {
 			return runFlagInteractive(flagList)
 		}
-
-		r, err := findReminderByID(args[0])
-		if err != nil {
-			return err
-		}
-
-		if err := reminderSvc.FlagReminder(r.ID); err != nil {
-			return err
-		}
-
-		fmt.Printf("Flagged: %s\n", r.Name)
-		return nil
+		return runBatchAction(args, "Flagged", reminderSvc.FlagReminder)
 	},
 }
 
 var unflagCmd = &cobra.Command{
-	Use:   "unflag [id]",
-	Short: "Remove flag from a reminder",
+	Use:   "unflag [id...]",
+	Short: "Remove flag from one or more reminders",
 	Example: `  rem unflag abc12345
+  rem unflag abc12345 def67890
   rem unflag -i
   rem unflag -i --list Work`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if unflagInteractive {
 			return cobra.MaximumNArgs(0)(cmd, args)
 		}
-		return cobra.ExactArgs(1)(cmd, args)
+		return cobra.MinimumNArgs(1)(cmd, args)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if unflagInteractive {
 			return runUnflagInteractive(unflagList)
 		}
-
-		r, err := findReminderByID(args[0])
-		if err != nil {
-			return err
-		}
-
-		if err := reminderSvc.UnflagReminder(r.ID); err != nil {
-			return err
-		}
-
-		fmt.Printf("Unflagged: %s\n", r.Name)
-		return nil
+		return runBatchAction(args, "Unflagged", reminderSvc.UnflagReminder)
 	},
 }
 

--- a/skills/rem-cli/SKILL.md
+++ b/skills/rem-cli/SKILL.md
@@ -3,7 +3,7 @@ name: rem-cli
 description: Create, list, update, complete, tag, and search macOS Reminders via the rem CLI. Use when the user wants to manage Apple Reminders from the terminal, automate reminder workflows, reference reminders in shell scripts, or schedule anything on macOS.
 license: MIT
 compatibility: Requires macOS with the rem CLI installed (https://rem.sidv.dev)
-allowed-tools: Bash(rem *)
+allowed-tools: Bash(rem *) Bash(echo *)
 argument-hint: "[natural language request]"
 metadata:
   author: BRO3886
@@ -136,8 +136,10 @@ rem update AB12 --url ""    # clear
 
 ### Daily briefing — one tool call, not three
 ```bash
-{ echo "== OVERDUE =="; rem overdue -o plain; echo "== TODAY =="; rem today -o plain; echo "== NEXT 3 DAYS =="; rem upcoming --days 3 -o plain; }
+echo "== OVERDUE =="; rem overdue -o plain; echo "== TODAY =="; rem today -o plain; echo "== NEXT 3 DAYS =="; rem upcoming --days 3 -o plain
 ```
+
+Chain with plain `;` (no `{ }` subshell grouping, no `$(...)` substitution) — permission allowlists check each `;`-separated segment, and `rem`/`echo` are pre-approved by this skill.
 
 ### Scripted cleanup
 ```bash

--- a/skills/rem-cli/SKILL.md
+++ b/skills/rem-cli/SKILL.md
@@ -53,11 +53,11 @@ Do NOT use rem for:
 | "remind me 15 minutes before" | add `--remind-me 15m` to `rem add` |
 | "make that one silent / no notification" | add `--silent` to `rem add` (not available in `-i` mode, see gotchas) |
 | "tell me more about X" / "show that reminder" | `rem show <short-id>` |
-| "mark X as done" | `rem complete <short-id>` |
-| "undo that / mark X as not done" | `rem uncomplete <short-id>` |
-| "delete X" | `rem delete <short-id>` (supports multiple IDs) |
+| "mark X as done" / "mark these done" | `rem complete <short-id>...` (supports multiple IDs) |
+| "undo that / mark X as not done" | `rem uncomplete <short-id>...` (supports multiple IDs) |
+| "delete X" | `rem delete <short-id>...` (supports multiple IDs) |
 | "find reminders about X" | `rem search "X"` |
-| "flag / unflag X" | `rem flag <short-id>` or `rem unflag <short-id>` |
+| "flag / unflag X" | `rem flag <short-id>...` or `rem unflag <short-id>...` (supports multiple IDs) |
 | "show me flagged stuff" | `rem list --flagged` |
 | "move X to list Y" | `rem update <short-id> --list "Y"` |
 | "change priority to high" | `rem update <short-id> --priority high` |
@@ -72,6 +72,13 @@ Do NOT use rem for:
 | "import this CSV" | `rem import file.csv --dry-run` first, then without |
 
 For full flag details on any command, load [references/commands.md](references/commands.md).
+
+## Batch everything into one tool call
+
+Every `rem` invocation is <200ms, so the expensive part is YOUR round trip, not the command. Two rules:
+
+1. **Multiple IDs, one command.** `complete`, `uncomplete`, `flag`, `unflag`, and `delete` all accept multiple IDs: `rem complete AB12 CD34 EF56`. Never loop one ID per call.
+2. **Multiple commands, one Bash call.** When answering one question needs several rem reads (or independent writes), chain them with `;` and header markers in a single Bash invocation — never run them as separate tool calls. See the daily briefing pattern below.
 
 ## Output formats (always set one when scripting)
 
@@ -117,7 +124,7 @@ rem update AB12 --url ""    # clear
 4. **Flagged and tags use private API.** Both go through Apple's private ReminderKit framework since EventKit doesn't expose these properties. Sub-200ms like everything else, but may break on future macOS versions. Both degrade gracefully — if the private API is unavailable, the reminder is still created/updated (just without the flag/tags) and a warning is printed on stderr. This applies to `flag`/`unflag` too, which behave exactly like `update --flagged`.
 5. **Tags from title are additive.** `#hashtags` in the title are parsed and stored as native Reminders.app tags. They stay in the title text AND become tag objects. Pure numbers like `#42` are ignored (treated as issue references, not tags).
 6. **`rem delete` prompts by default.** Pass `--force` / `--yes` / `-y` when scripting to skip the confirmation.
-7. **`rem add -i` (interactive form) has no `--silent` equivalent.** If a user wants a silent reminder via the interactive flow, create it normally and then run `rem update <id> --remind-me none` to clear the alarm.
+7. **`rem add -i` (interactive form) has no `--silent` equivalent.** If a user wants a silent reminder via the interactive flow, create it then clear the alarm in the same Bash call: `id=$(rem add "Task" --due tomorrow -o json | jq -r '.id'); rem update "$id" --remind-me none`.
 8. **Old reminders with URLs in the notes body** (`URL: https://...`) still read correctly as a backward-compat fallback. New reminders always use the native URL field.
 
 ## Reference files (load when needed)
@@ -127,11 +134,9 @@ rem update AB12 --url ""    # clear
 
 ## Common patterns
 
-### Daily briefing
+### Daily briefing — one tool call, not three
 ```bash
-rem overdue -o plain
-rem today -o plain
-rem upcoming --days 3 -o plain
+{ echo "== OVERDUE =="; rem overdue -o plain; echo "== TODAY =="; rem today -o plain; echo "== NEXT 3 DAYS =="; rem upcoming --days 3 -o plain; }
 ```
 
 ### Scripted cleanup

--- a/skills/rem-cli/references/commands.md
+++ b/skills/rem-cli/references/commands.md
@@ -144,10 +144,11 @@ Aliases: `rm`, `remove`
 
 ## rem complete
 
-Mark a reminder as complete.
+Mark one or more reminders as complete.
 
 ```bash
 rem complete abc12345
+rem complete abc12345 def67890
 rem done abc12345
 ```
 
@@ -157,30 +158,33 @@ Aliases: `done`
 
 ## rem uncomplete
 
-Mark a reminder as incomplete.
+Mark one or more reminders as incomplete.
 
 ```bash
 rem uncomplete abc12345
+rem uncomplete abc12345 def67890
 ```
 
 ---
 
 ## rem flag
 
-Flag a reminder.
+Flag one or more reminders.
 
 ```bash
 rem flag abc12345
+rem flag abc12345 def67890
 ```
 
 ---
 
 ## rem unflag
 
-Remove flag from a reminder.
+Remove flag from one or more reminders.
 
 ```bash
 rem unflag abc12345
+rem unflag abc12345 def67890
 ```
 
 ---

--- a/website/content/docs/commands.md
+++ b/website/content/docs/commands.md
@@ -131,28 +131,31 @@ rem update 6ECE --remove-tags "urgent"      # remove tags
 
 ### `rem complete`
 
-Mark a reminder as completed.
+Mark one or more reminders as completed.
 
 ```bash
 rem complete 6ECE
+rem complete 6ECE A1B2 C3D4    # batch complete
 ```
 
 **Aliases:** `done`
 
 ### `rem uncomplete`
 
-Mark a completed reminder as incomplete.
+Mark one or more completed reminders as incomplete.
 
 ```bash
 rem uncomplete 6ECE
+rem uncomplete 6ECE A1B2
 ```
 
 ### `rem flag` / `rem unflag`
 
-Toggle the flag on a reminder.
+Toggle the flag on one or more reminders.
 
 ```bash
 rem flag 6ECE
+rem flag 6ECE A1B2    # batch flag
 rem unflag 6ECE
 ```
 


### PR DESCRIPTION
Closes #53

Authored by Claude (model: Fable 5, id: `claude-fable-5[1m]`), as requested.

## What

- `rem complete`, `uncomplete`, `flag`, `unflag` now accept multiple IDs, matching `rem delete`. Shared `runBatchAction` helper in `cmd/rem/commands/batch.go`: resolves all IDs up front (a typo'd ID fails the whole command before anything mutates), continues past per-item errors, exits non-zero if any failed. Single-ID output is byte-identical to before.
- rem-cli skill: new "Batch everything into one tool call" section (multi-ID + shell chaining rules), daily-briefing example rewritten as one chained invocation, gotcha 7 rewritten as a one-call `add` + `update` pipeline.
- Docs: README, website commands reference, skill references/commands.md, CLAUDE.md conventions.

## Testing

- Unit tests for `applyBatch` (single success/failure passthrough, multi success, partial failure continues + non-zero exit, empty).
- Smoke test on a temp list (created and deleted as part of the test): multi flag/unflag/complete/uncomplete, single-ID behavior, bad-ID fail-fast before mutation.
- `go test ./...` — 196 passed; `go vet` clean; `make build` clean.
