### PR TITLE
Document shared-list support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A blazing fast CLI for macOS Reminders. Sub-200ms reads AND writes via EventKit,
 - **20 commands** — full CRUD, search, stats, overdue, upcoming, interactive mode
 - **Multiple output formats** — table, JSON, plain text
 - **Native tags** — `#hashtag` in titles or `--tags` flag, stored as real Reminders.app tags
+- **Shared list support** — full CRUD on shared lists, sharing state in `rem lists`, and moves across the shared-list boundary via copy (macOS has no true move there)
 - **Import/Export** — JSON and CSV with full property round-trip (including tags)
 - **Powered by [go-eventkit](https://github.com/BRO3886/go-eventkit)** — use the same library directly for programmatic Go access
 - **Shell completions** — bash, zsh, fish
@@ -334,7 +335,9 @@ rem/
 
 **All reads and writes** — including reminder CRUD and list CRUD — go through `go-eventkit` (`github.com/BRO3886/go-eventkit`) — an Objective-C EventKit bridge compiled into the binary via cgo. Direct in-process access to the Reminders store, no IPC. All operations complete in under 200ms.
 
-**Flagged and tag operations** use the private ReminderKit bridge in go-eventkit — EventKit doesn't expose these properties, but `REMReminder.flagged` and `REMReminder.hashtags` do. Tags degrade gracefully if the private API becomes unavailable. AppleScript is only used for the default list name query.
+**Flagged, tag, and list-sharing operations** use the private ReminderKit bridge in go-eventkit — EventKit doesn't expose these properties, but `REMReminder.flagged`, `REMReminder.hashtags`, and `REMList.isShared` do. Tags degrade gracefully if the private API becomes unavailable. AppleScript is only used for the default list name query.
+
+**Shared lists** work like any other list for creates, reads, updates, flags, tags, and deletes. Moving a reminder across a shared-list boundary is the one exception: macOS refuses a true move there (even Apple's own apps copy and delete behind the scenes), so rem does the same — the reminder is copied to the target with all fields intact, the original is deleted, and a warning with the new ID is printed to stderr.
 
 ## Performance
 
@@ -354,7 +357,8 @@ See [Performance docs](https://rem.sidv.dev/docs/performance/) for the full opti
 
 - **macOS only** — requires EventKit framework and osascript
 - **No subtasks** — not exposed via EventKit
-- **Tags and flagged use private API** — reads/writes go through Apple's private ReminderKit framework since EventKit doesn't expose these properties. If Apple changes the private API in a future macOS version, tags degrade gracefully (reminder is created/updated without tags, a warning is printed) while flagged currently degrades silently. See [#44](https://github.com/BRO3886/rem/issues/44) for tracking consistency
+- **Tags, flagged, and list-sharing state use private API** — reads/writes go through Apple's private ReminderKit framework since EventKit doesn't expose these properties. If Apple changes the private API in a future macOS version, tags and flagged degrade gracefully (the reminder is still created/updated, a warning is printed — see [#44](https://github.com/BRO3886/rem/issues/44)) and lists simply report as unshared
+- **No true move across shared-list boundaries** — macOS refuses it at the account level, so rem moves to/from shared lists by copy + delete; the reminder gets a new ID (warned on stderr). See [#50](https://github.com/BRO3886/rem/issues/50)
 - **Immutable lists** cannot be renamed or deleted (system lists like Siri suggestions)
 
 ## License

--- a/skills/rem-cli/SKILL.md
+++ b/skills/rem-cli/SKILL.md
@@ -59,7 +59,7 @@ Do NOT use rem for:
 | "find reminders about X" | `rem search "X"` |
 | "flag / unflag X" | `rem flag <short-id>...` or `rem unflag <short-id>...` (supports multiple IDs) |
 | "show me flagged stuff" | `rem list --flagged` |
-| "move X to list Y" | `rem update <short-id> --list "Y"` |
+| "move X to list Y" | `rem update <short-id> --list "Y"` (shared lists: new ID, see gotchas) |
 | "change priority to high" | `rem update <short-id> --priority high` |
 | "add notes to X" | `rem update <short-id> --notes "..."` |
 | "tag this as work" / "add tags" | `rem add "Task #work"` or `rem update <short-id> --add-tags "work,urgent"` |
@@ -126,6 +126,7 @@ rem update AB12 --url ""    # clear
 6. **`rem delete` prompts by default.** Pass `--force` / `--yes` / `-y` when scripting to skip the confirmation.
 7. **`rem add -i` (interactive form) has no `--silent` equivalent.** If a user wants a silent reminder via the interactive flow, create it then clear the alarm in the same Bash call: `id=$(rem add "Task" --due tomorrow -o json | jq -r '.id'); rem update "$id" --remind-me none`.
 8. **Old reminders with URLs in the notes body** (`URL: https://...`) still read correctly as a backward-compat fallback. New reminders always use the native URL field.
+9. **Moving to/from a shared list changes the reminder's ID.** macOS has no true move across a shared-list boundary, so rem copies the reminder (all fields preserved, including completed state) and deletes the original, warning on stderr with the new ID. **Re-resolve the ID after such a move** — the old short ID is gone. Plain (non-shared) moves keep the ID. Shared lists are marked in `rem lists` output (`[shared]` in plain, `(shared)` in table) and carry `IsShared`/`SharedToMe`/`IsOwnedByMe` in JSON.
 
 ## Reference files (load when needed)
 

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -159,6 +159,9 @@ err := client.DeleteReminder(id)
 lists, err := client.Lists()
 for _, l := range lists {
     fmt.Printf("%s (%d reminders, source: %s)\n", l.Title, l.Count, l.Source)
+    if l.IsShared { // sharing state: IsShared, SharedToMe, IsOwnedByMe (go-eventkit ≥ v0.12.0)
+        fmt.Println("  shared list — moves in/out will be copy+delete")
+    }
 }
 
 // Create a list

--- a/website/content/docs/architecture.md
+++ b/website/content/docs/architecture.md
@@ -102,8 +102,15 @@ EventKit's `EKReminder` does not expose flagged state, the real URL field, or ha
 - **Flagged** — read via KVC (`valueForKey:@"flagged"` on `REMReminder`), write via `REMSaveRequest` → `flaggedContext.setFlagged:`
 - **URL attachments** — write via `REMSaveRequest` → `attachmentContext.setURLAttachmentWithURL:`
 - **Tags** — read via KVC (`valueForKey:@"hashtags"` on `REMReminder`), write via `REMSaveRequest` → `hashtagContext.addHashtagWithType:name:`
+- **List sharing state** — read via KVC on `REMList` (`isShared`, `sharedToMe`, `isOwnedByMe`); EventKit exposes no sharing information for reminder lists
 
-All private API calls are guarded by `respondsToSelector:` checks and complete in under 200ms. Tags degrade gracefully — if the private API becomes unavailable, the reminder is created/updated without tags and a warning is printed. Flagged and URL operations also degrade cleanly.
+All private API calls are guarded by `respondsToSelector:` checks and complete in under 200ms. Tags degrade gracefully — if the private API becomes unavailable, the reminder is created/updated without tags and a warning is printed. Flagged and URL operations also degrade cleanly, and lists simply report as unshared.
+
+## Shared lists and moves
+
+Shared lists behave like any other list for creates, reads, updates, flags, tags, and deletes. Moves are the exception. ReminderKit refuses to move a reminder across a shared-list boundary at the account-capability level (`com.apple.reminderkit error -3002`), regardless of whether you own the share — and Apple's own move paths (Reminders.app, AppleScript's `move`) quietly copy and delete behind the scenes, producing a new reminder ID.
+
+rem does the same, but says so. When a move involves a shared list (detected via the sharing booleans above), rem copies the reminder to the target with every field intact — notes, dates, priority, URL, flagged, tags, alarms, recurrence, completed state — deletes the original, and prints a warning with the new ID to stderr. Plain moves between unshared lists stay native and keep the reminder's ID.
 
 ## AppleScript fallback
 
@@ -144,7 +151,7 @@ rem uses five external Go dependencies:
 
 | Package | Purpose |
 |---------|---------|
-| `BRO3886/go-eventkit` v0.9.0+ | Native EventKit bindings (cgo + ObjC, reads AND writes). Includes the private ReminderKit bridge for flagged state, URL attachments, and hashtags. |
+| `BRO3886/go-eventkit` v0.12.0+ | Native EventKit bindings (cgo + ObjC, reads AND writes). Includes the private ReminderKit bridge for flagged state, URL attachments, hashtags, and list sharing state. |
 | `spf13/cobra` | CLI framework (commands, flags, help) |
 | `olekukonko/tablewriter` | Terminal table formatting |
 | `fatih/color` | Terminal colors |

--- a/website/content/docs/commands.md
+++ b/website/content/docs/commands.md
@@ -114,6 +114,8 @@ rem update 6ECE --remove-tags "urgent"      # remove tags
 
 `--add-tags` and `--remove-tags` accept comma-separated tag names. Tags in `--name` are also parsed as hashtags. Tags use the private ReminderKit API and degrade gracefully if unavailable.
 
+`--list` moves the reminder. Plain moves are native and keep the reminder's ID. Moving to or from a **shared list** is different: macOS has no true move across that boundary (Apple's own apps copy and delete behind the scenes), so rem copies the reminder — all fields preserved, including completed state — deletes the original, and prints a warning with the **new ID** on stderr. Re-resolve the ID after such a move.
+
 | Flag | Description |
 |------|-------------|
 | `--name` | New title |
@@ -253,6 +255,8 @@ rem lists --count    # include reminder count per list
 | Flag | Description |
 |------|-------------|
 | `-c, --count` | Show reminder count per list |
+
+Shared lists are marked — `(shared)` in table output, `[shared]` in plain. JSON output carries three booleans per list: `IsShared`, `SharedToMe` (someone shared it with you), and `IsOwnedByMe`.
 
 ### `rem list-mgmt`
 


### PR DESCRIPTION
## Summary

Documentation for the shared-list support shipped in #55. No code changes.

- **README**: shared-list feature bullet, shared-move explanation in the architecture section, refreshed known limitations (adds the no-true-move limitation with the copy+delete behavior; corrects the stale claim that flagged degrades silently — graceful since #44)
- **Website / commands**: `rem update --list` now explains plain moves keep the ID while shared moves copy + delete with a stderr warning and a new ID; `rem lists` documents the shared markers and the three JSON booleans
- **Website / architecture**: list sharing state added to the private ReminderKit bridge list, plus a new "Shared lists and moves" section explaining the -3002 capability gate and why Apple's own move is copy+delete
- **Website / api**: sharing booleans shown in the `Lists()` example, go-eventkit dependency note bumped to v0.12.0
- **Agent skill**: decision-tree pointer plus a critical gotcha — moving to/from a shared list changes the reminder's ID, so agents must re-resolve it

CLAUDE.md was already updated as part of #55.
