### PR TITLE
Default the install script to ~/.local/bin so it no longer needs sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ brew install rem-cli
 curl -fsSL https://rem.sidv.dev/install | bash
 ```
 
-Downloads the latest release, extracts, and installs to `/usr/local/bin`.
+Downloads the latest release, extracts, and installs to `~/.local/bin` (override with `INSTALL_DIR=...`). No sudo needed.
 
 ### Via Go
 
@@ -50,12 +50,12 @@ Download from [GitHub Releases](https://github.com/BRO3886/rem/releases):
 # Apple Silicon
 curl -LO https://github.com/BRO3886/rem/releases/latest/download/rem-darwin-arm64.tar.gz
 tar xzf rem-darwin-arm64.tar.gz
-sudo mv rem /usr/local/bin/rem
+mkdir -p ~/.local/bin && mv rem ~/.local/bin/rem
 
 # Intel
 curl -LO https://github.com/BRO3886/rem/releases/latest/download/rem-darwin-amd64.tar.gz
 tar xzf rem-darwin-amd64.tar.gz
-sudo mv rem /usr/local/bin/rem
+mkdir -p ~/.local/bin && mv rem ~/.local/bin/rem
 ```
 
 ### Build from source

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,10 +5,11 @@ set -euo pipefail
 # Usage: curl -fsSL https://rem.sidv.dev/install | bash
 
 REPO="BRO3886/rem"
-INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 BINARY_NAME="rem"
 
 info() { printf "\033[36m%s\033[0m\n" "$*"; }
+warn() { printf "\033[33m%s\033[0m\n" "$*"; }
 error() { printf "\033[31mError: %s\033[0m\n" "$*" >&2; exit 1; }
 
 # --- Pre-flight checks ---
@@ -60,6 +61,10 @@ tar -xzf "${TMPDIR_PATH}/${ASSET_NAME}" -C "${TMPDIR_PATH}"
 
 # --- Install ---
 
+if [ ! -d "$INSTALL_DIR" ]; then
+    mkdir -p "$INSTALL_DIR" 2>/dev/null || sudo mkdir -p "$INSTALL_DIR"
+fi
+
 if [ -w "$INSTALL_DIR" ]; then
     mv "${TMPDIR_PATH}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
 else
@@ -69,20 +74,41 @@ fi
 
 info "Installed rem ${LATEST} to ${INSTALL_DIR}/${BINARY_NAME}"
 
-# --- Verify ---
+# --- Old install cleanup notice ---
 
-if command -v rem >/dev/null 2>&1; then
-    info "Run 'rem --help' to get started"
-else
-    info "Note: ${INSTALL_DIR} may not be in your PATH"
+if [ "$INSTALL_DIR" != "/usr/local/bin" ] && [ -e "/usr/local/bin/${BINARY_NAME}" ]; then
+    warn "An older rem exists at /usr/local/bin/${BINARY_NAME}."
+    warn "Remove it to avoid PATH confusion: sudo rm /usr/local/bin/${BINARY_NAME}"
 fi
+
+# --- PATH check ---
+
+case ":$PATH:" in
+    *":${INSTALL_DIR}:"*)
+        info "Run 'rem --help' to get started"
+        ;;
+    *)
+        warn "${INSTALL_DIR} is not in your PATH."
+        case "${SHELL:-}" in
+            */zsh)
+                warn "Add it with: echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.zshrc && source ~/.zshrc"
+                ;;
+            */fish)
+                warn "Add it with: fish_add_path ${INSTALL_DIR}"
+                ;;
+            *)
+                warn "Add it with: echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.bashrc && source ~/.bashrc"
+                ;;
+        esac
+        ;;
+esac
 
 # --- Agent skill installation ---
 
 echo ""
 info "rem can install an AI agent skill that teaches Claude Code / Codex / OpenClaw how to use it."
 printf "Install agent skill now? [Y/n] "
-read -r answer < /dev/tty 2>/dev/null || answer="n"
+{ read -r answer < /dev/tty; } 2>/dev/null || answer="n"
 if [ "$answer" != "n" ] && [ "$answer" != "N" ]; then
     "${INSTALL_DIR}/${BINARY_NAME}" skills install || true
 fi

--- a/website/static/install
+++ b/website/static/install
@@ -5,10 +5,11 @@ set -euo pipefail
 # Usage: curl -fsSL https://rem.sidv.dev/install | bash
 
 REPO="BRO3886/rem"
-INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 BINARY_NAME="rem"
 
 info() { printf "\033[36m%s\033[0m\n" "$*"; }
+warn() { printf "\033[33m%s\033[0m\n" "$*"; }
 error() { printf "\033[31mError: %s\033[0m\n" "$*" >&2; exit 1; }
 
 # --- Pre-flight checks ---
@@ -60,6 +61,10 @@ tar -xzf "${TMPDIR_PATH}/${ASSET_NAME}" -C "${TMPDIR_PATH}"
 
 # --- Install ---
 
+if [ ! -d "$INSTALL_DIR" ]; then
+    mkdir -p "$INSTALL_DIR" 2>/dev/null || sudo mkdir -p "$INSTALL_DIR"
+fi
+
 if [ -w "$INSTALL_DIR" ]; then
     mv "${TMPDIR_PATH}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
 else
@@ -69,20 +74,41 @@ fi
 
 info "Installed rem ${LATEST} to ${INSTALL_DIR}/${BINARY_NAME}"
 
-# --- Verify ---
+# --- Old install cleanup notice ---
 
-if command -v rem >/dev/null 2>&1; then
-    info "Run 'rem --help' to get started"
-else
-    info "Note: ${INSTALL_DIR} may not be in your PATH"
+if [ "$INSTALL_DIR" != "/usr/local/bin" ] && [ -e "/usr/local/bin/${BINARY_NAME}" ]; then
+    warn "An older rem exists at /usr/local/bin/${BINARY_NAME}."
+    warn "Remove it to avoid PATH confusion: sudo rm /usr/local/bin/${BINARY_NAME}"
 fi
+
+# --- PATH check ---
+
+case ":$PATH:" in
+    *":${INSTALL_DIR}:"*)
+        info "Run 'rem --help' to get started"
+        ;;
+    *)
+        warn "${INSTALL_DIR} is not in your PATH."
+        case "${SHELL:-}" in
+            */zsh)
+                warn "Add it with: echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.zshrc && source ~/.zshrc"
+                ;;
+            */fish)
+                warn "Add it with: fish_add_path ${INSTALL_DIR}"
+                ;;
+            *)
+                warn "Add it with: echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.bashrc && source ~/.bashrc"
+                ;;
+        esac
+        ;;
+esac
 
 # --- Agent skill installation ---
 
 echo ""
 info "rem can install an AI agent skill that teaches Claude Code / Codex / OpenClaw how to use it."
 printf "Install agent skill now? [Y/n] "
-read -r answer < /dev/tty 2>/dev/null || answer="n"
+{ read -r answer < /dev/tty; } 2>/dev/null || answer="n"
 if [ "$answer" != "n" ] && [ "$answer" != "N" ]; then
     "${INSTALL_DIR}/${BINARY_NAME}" skills install || true
 fi

--- a/website/themes/rem-docs/layouts/index.html
+++ b/website/themes/rem-docs/layouts/index.html
@@ -237,7 +237,7 @@ brew install rem-cli</code>
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
             </button>
           </div>
-          <span class="install-note">Downloads the latest release binary and installs to /usr/local/bin.</span>
+          <span class="install-note">Downloads the latest release binary and installs to ~/.local/bin. No sudo needed.</span>
         </div>
       </div>
 
@@ -260,8 +260,8 @@ brew install rem-cli</code>
           <div class="code-block code-block-multi">
             <code>curl -LO https://github.com/BRO3886/rem/releases/latest/download/rem-darwin-arm64.tar.gz
 tar xzf rem-darwin-arm64.tar.gz
-sudo mv rem /usr/local/bin/rem</code>
-            <button class="copy-btn" data-copy="curl -LO https://github.com/BRO3886/rem/releases/latest/download/rem-darwin-arm64.tar.gz && tar xzf rem-darwin-arm64.tar.gz && sudo mv rem /usr/local/bin/rem" aria-label="Copy">
+mkdir -p ~/.local/bin &amp;&amp; mv rem ~/.local/bin/rem</code>
+            <button class="copy-btn" data-copy="curl -LO https://github.com/BRO3886/rem/releases/latest/download/rem-darwin-arm64.tar.gz && tar xzf rem-darwin-arm64.tar.gz && mkdir -p ~/.local/bin && mv rem ~/.local/bin/rem" aria-label="Copy">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
             </button>
           </div>


### PR DESCRIPTION
## Summary

Switches the install script default from `/usr/local/bin` to `~/.local/bin`, following the convention used by rustup, uv, mise, bun, and deno. On Apple Silicon, `/usr/local/bin` is root-owned for anyone without Intel Homebrew, so the previous default forced a sudo prompt in a `curl | bash` one-liner — exactly where users (rightly) hesitate.

## Changes

- `INSTALL_DIR` defaults to `$HOME/.local/bin`; the env var override is unchanged, so `INSTALL_DIR=/usr/local/bin` keeps working (with the existing sudo fallback)
- Creates the install dir with `mkdir -p` if missing
- After install, checks whether the dir is on `PATH`; if not, prints a one-liner fix tailored to the user's shell (zsh, fish, bash)
- If a stale copy exists at `/usr/local/bin/rem` after installing elsewhere, prints a notice suggesting `sudo rm /usr/local/bin/rem`
- Fixes a pre-existing wart: in non-TTY runs the `read < /dev/tty` for the agent-skill prompt leaked a `Device not configured` error because the stderr redirect was applied after the failing input redirect
- `website/static/install` re-synced (byte-identical copy), README and website install sections updated to drop sudo

## Testing

- `bash -n` clean
- Full run with `INSTALL_DIR=<tmpdir>` and stdin from `/dev/null`: dir created, binary installed, PATH warning with correct zsh one-liner, skill prompt skipped silently, exit 0
- Second run with the tmpdir already on `PATH`: prints the `rem --help` hint instead of the warning

Closes #29
