### PR TITLE
Refer to the app as Apple Reminders in titles and hero

### DIFF
--- a/website/config.yaml
+++ b/website/config.yaml
@@ -1,10 +1,10 @@
 baseURL: "https://rem.sidv.dev/"
 languageCode: "en-us"
-title: "rem — CLI for macOS Reminders"
+title: "rem — CLI for Apple Reminders"
 theme: "rem-docs"
 
 params:
-  description: "rem is a fast command-line interface for macOS Reminders. Built with Go and EventKit via cgo, it reads and writes reminders in under 200ms — faster than any AppleScript or JXA approach. Supports natural language dates, JSON/CSV export, interactive mode, and AI agent skills."
+  description: "rem is a fast command-line interface for Apple Reminders. Built with Go and EventKit via cgo, it reads and writes reminders in under 200ms — faster than any AppleScript or JXA approach. Supports natural language dates, JSON/CSV export, interactive mode, and AI agent skills."
   author: "Siddharth Verma"
   github: "https://github.com/BRO3886/rem"
   ogImage: "/images/og-image.png"

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "rem — CLI for macOS Reminders"
-description: "rem is a fast command-line interface for macOS Reminders. Built with Go and EventKit via cgo, it reads and writes reminders in under 200ms. Supports natural language dates, JSON/CSV export, interactive mode, and AI agent skills for Claude Code, Codex, and OpenClaw."
+title: "rem — CLI for Apple Reminders"
+description: "rem is a fast command-line interface for Apple Reminders. Built with Go and EventKit via cgo, it reads and writes reminders in under 200ms. Supports natural language dates, JSON/CSV export, interactive mode, and AI agent skills for Claude Code, Codex, and OpenClaw."
 keywords:
   - rem CLI macOS Reminders
   - macOS Reminders command line

--- a/website/themes/rem-docs/layouts/index.html
+++ b/website/themes/rem-docs/layouts/index.html
@@ -6,7 +6,7 @@
 <section class="hero">
   <div class="hero-inner">
     <h1 class="hero-title fade-in">
-      macOS Reminders,<br>
+      Apple Reminders,<br>
       <span class="hero-accent">from the terminal.</span>
     </h1>
     <div class="hero-chips fade-in delay-1">


### PR DESCRIPTION
Renames the prominent product references on the site from "macOS Reminders" to "Apple Reminders" — the app's actual product name. Scoped to the big-print / title surfaces, not the technical OS references.

## Changed
- Site title (`config.yaml`) and homepage `title` — now "rem — CLI for Apple Reminders"
- Homepage hero headline — now reads "Apple Reminders,"
- The matching homepage meta descriptions (`config.yaml` + `_index.md`)

## Left as macOS (genuine OS references, not the app name)
- Version requirements (`macOS 10.12+`), permission prompts, `EventKit`/`macOS native` framework mentions, platform notes, and the docs body
- SEO keyword arrays — these already dual-target both "macOS Reminders" and "Apple Reminders" on purpose

## Note
The visually-hidden GEO entity block at the top of the homepage still says "macOS Reminders". I left it since it isn't a visible title, but it's the description answer-engines read — happy to switch it to "Apple Reminders" too if you want the entity name to match the visible brand.

## Verification
`hugo` builds clean; rendered `public/index.html` shows `<title>rem — CLI for Apple Reminders</title>` and the "Apple Reminders," hero.
