### PR TITLE
Lengthen short docs meta description flagged by Bing Webmaster

### DIFF
--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Documentation"
-description: "Complete documentation for the rem CLI tool."
+description: "Documentation for rem, the fast CLI for Apple Reminders: getting started, reference for all 20 commands, architecture, Go API, and performance benchmarks."
 ---
 
 ## Documentation


### PR DESCRIPTION
Bing Webmaster flagged rem.sidv.dev/docs/ for a meta description below the recommended length (the old one was 44 characters). This rewrites the frontmatter `description` to a 154-character summary of the documentation sections.

Verified by building the Hugo site (`hugo --minify`) and reading the rendered `<meta name="description">` in `website/public/docs/index.html` (154 chars). Source-only change to markdown frontmatter.
