### PR TITLE
Simplify skill by removing date commands

### DIFF
--- a/skills/rem-cli/SKILL.md
+++ b/skills/rem-cli/SKILL.md
@@ -14,18 +14,11 @@ metadata:
 
 rem is a single-binary Go CLI that reads and writes the Apple Reminders database in under 200ms via EventKit (cgo). Every `rem` invocation is fast and safe to run.
 
-## Current time (do not guess, use these values)
+## Relative time
 
-- Today: !`date +"%A, %B %-d, %Y"`
-- ISO date: !`date +"%Y-%m-%d"`
-- Local time: !`date +"%H:%M %Z"`
-- Day of week: !`date +"%A"`
-- Tomorrow (ISO): !`date -v+1d +"%Y-%m-%d"`
-- Next Friday (ISO, always forward): !`date -v+1d -v+fri +"%Y-%m-%d"`
+**When the user says relative dates like "tomorrow", "next friday", "end of week", or "last tuesday", use the `--due` flag. Don't guess from training data.**
 
-**When the user says relative dates like "tomorrow", "next friday", "end of week", or "last tuesday", resolve them against the values above before calling rem.** Don't ask the user "what is today" and don't guess from training data.
-
-rem's `--due` flag accepts natural language directly (see [references/dates.md](references/dates.md)), so in many cases you can pass the user's phrase through verbatim. But if the user asks something ambiguous ("what was I supposed to do yesterday?"), use the ISO date above and query rem with `--due-before` / `--due-after` against an exact date.
+rem's `--due` flag accepts natural language directly (see [references/dates.md](references/dates.md)), so in many cases you can pass the user's phrase through verbatim.
 
 ## When to use this skill
 


### PR DESCRIPTION
The skill currently injects timestamps at load time in order to handle relative dates. This is problematic because 1) this shell interpolation feature is not portable across agents, and 2) with normal permissions regime, loading this will fail because the `date` command is not in the `allowed-tools` field.

Separately, it's not clear when and why to use this rule vs rem's built-in relative time handling via --due. The skill says "rem's --due flag accepts natural language directly" which contradicts "When the user says relative dates ... resolve them against the values above before calling rem".